### PR TITLE
CFY-2649 fix failing test_local_agent_from_package test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,13 @@ environment:
 install:
 
   #################################
+  # Change Python Registry
+  #################################
+
+  - reg ADD HKCU\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+  - reg ADD HKLM\Software\Python\PythonCore\2.7\InstallPath /ve /d "C:\Python27" /t REG_SZ /f
+
+  #################################
   # Installing Inno Setup
   #################################
 


### PR DESCRIPTION
appveyor environment change caused package install under wrong python (miniconda 64bit)