### PR TITLE
CFY-3583-remove-dsl-parser-from-agent-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
-https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/master.zip
 https://github.com/cloudify-cosmo/cloudify-rest-client/archive/master.zip
 https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/master.zip
 https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/master.zip

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@ testtools
 mock==1.0.1
 unittest2
 FileServer
+https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/master.zip
 
 # for creating the agent package in tests
 https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/master.zip


### PR DESCRIPTION
moved dsl parser from dev-requirements to test-requirements