### PR TITLE
CFY-5111 use virtualenv's method of fixing shebangs

### DIFF
--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -110,6 +110,14 @@ class AgentInstaller(object):
         self.runner.run('{0} install {1}'
                         .format(pip_path, source_url))
 
+        # scripts inside the virtualenv will have /path/to/venv/bin/python
+        # as their shebang. If this exceeds 128 bytes, the scripts will
+        # become non-executable, unless make the virtualenv relocatable
+        # Do this after installing the agent, so that the agent script
+        # is also made relocatable
+        self.runner.run('virtualenv --relocatable {0}'.format(
+            self.cloudify_agent['envdir']))
+
     def _from_package(self):
 
         self.logger.info('Downloading Agent Package from {0}'.format(
@@ -259,7 +267,8 @@ class LinuxInstallerMixin(AgentInstaller):
         get_pip = self.download(get_pip_url)
         self.logger.info('Running pip installation script')
         self.runner.run('sudo python {0}'.format(get_pip))
-        return '{0}/bin/pip'.format(self.cloudify_agent['envdir'])
+        return '{0}/bin/python {0}/bin/pip'.format(
+            self.cloudify_agent['envdir'])
 
     def install_virtualenv(self):
         self.runner.run('sudo pip install virtualenv')

--- a/cloudify_agent/tests/installer/test_operations.py
+++ b/cloudify_agent/tests/installer/test_operations.py
@@ -13,7 +13,9 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+import shutil
 import tempfile
+import uuid
 
 from mock import patch
 
@@ -26,7 +28,7 @@ from cloudify_agent.tests.utils import (
     get_source_uri,
     get_requirements_uri)
 from cloudify_agent.tests.api.pm import BaseDaemonLiveTestCase
-from cloudify_agent.tests.api.pm import only_ci
+from cloudify_agent.tests.api.pm import only_ci, only_os
 from cloudify_agent.api import utils
 
 
@@ -45,31 +47,63 @@ class AgentInstallerLocalTest(BaseDaemonLiveTestCase):
     operations. the remote use case is tested as part of the system tests.
     """
 
-    fs = None
-
     @classmethod
     def setUpClass(cls):
         cls.logger = setup_logger(cls.__name__)
-        cls.resource_base = tempfile.mkdtemp(
-            prefix='file-server-resource-base')
-        cls.fs = FileServer(
-            root_path=cls.resource_base)
-        cls.fs.start()
-
         cls.source_url = get_source_uri()
         cls.requirements_file = get_requirements_uri()
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.fs.stop()
+    def setUp(self):
+        super(AgentInstallerLocalTest, self).setUp()
+        self.resource_base = tempfile.mkdtemp(
+            prefix='file-server-resource-base')
+        self.fs = FileServer(
+            root_path=self.resource_base)
+        self.fs.start()
+
+        self.addCleanup(self.fs.stop)
+        self.addCleanup(shutil.rmtree, self.resource_base)
 
     @patch.dict('agent_packager.logger.LOGGER',
                 disable_existing_loggers=False)
     @patch('cloudify.workflows.local._validate_node')
     @only_ci
     def test_local_agent_from_package(self, _):
-
         agent_name = utils.internal.generate_agent_name()
+        agent_queue = '{0}-queue'.format(agent_name)
+
+        blueprint_path = resources.get_resource(
+            'blueprints/agent-from-package/local-agent-blueprint.yaml')
+        self.logger.info('Initiating local env')
+
+        inputs = {
+            'resource_base': self.resource_base,
+            'source_url': self.source_url,
+            'requirements_file': self.requirements_file,
+            'name': agent_name,
+            'queue': agent_queue,
+            'file_server_port': self.fs.port
+        }
+
+        env = local.init_env(name=self._testMethodName,
+                             blueprint_path=blueprint_path,
+                             inputs=inputs)
+
+        env.execute('install', task_retries=0)
+        self.assert_daemon_alive(name=agent_name)
+
+        env.execute('uninstall', task_retries=1)
+        self.wait_for_daemon_dead(name=agent_name)
+
+    @only_os('posix')
+    @patch('cloudify.workflows.local._validate_node')
+    @only_ci
+    def test_local_agent_from_package_long_name(self, _):
+        """Agent still works with a filepath longer than 128 bytes
+
+        Paths longer than 128 bytes break shebangs on linux.
+        """
+        agent_name = 'agent-' + ''.join(uuid.uuid4().hex for i in range(4))
         agent_queue = '{0}-queue'.format(agent_name)
 
         blueprint_path = resources.get_resource(
@@ -142,6 +176,39 @@ class AgentInstallerLocalTest(BaseDaemonLiveTestCase):
 
         blueprint_path = resources.get_resource(
             'blueprints/3_2-agent-from-source/3_2-agent-from-source.yaml')
+        self.logger.info('Initiating local env')
+        env = local.init_env(name=self._testMethodName,
+                             blueprint_path=blueprint_path,
+                             inputs=inputs)
+
+        env.execute('install', task_retries=0)
+        self.assert_daemon_alive(name=agent_name)
+
+        env.execute('uninstall', task_retries=1)
+        self.wait_for_daemon_dead(name=agent_name)
+
+    @only_os('posix')
+    @only_ci
+    @patch('cloudify.workflows.local._validate_node')
+    def test_local_agent_from_source_long_name(self, _):
+        """Agent still works with a filepath longer than 128 bytes
+
+        This test won't pass on windows because some files within the
+        virtualenv exceed 256 bytes, and windows doesn't support paths
+        that long.
+        """
+        agent_name = 'agent-' + ''.join(uuid.uuid4().hex for i in range(4))
+        agent_queue = '{0}-queue'.format(agent_name)
+
+        inputs = {
+            'source_url': self.source_url,
+            'requirements_file': self.requirements_file,
+            'name': agent_name,
+            'queue': agent_queue
+        }
+
+        blueprint_path = resources.get_resource(
+            'blueprints/agent-from-source/local-agent-blueprint.yaml')
         self.logger.info('Initiating local env')
         env = local.init_env(name=self._testMethodName,
                              blueprint_path=blueprint_path,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ install_requires = [
     'fabric==1.8.3',
     'wagon==0.3.0',
     'fasteners==0.13.0',
-    'pyzmq==15.1.0'
+    'pyzmq==15.1.0',
+    'virtualenv>=12.1'
 ]
 
 setup(


### PR DESCRIPTION
the previous _fix_virtualenv method left the scripts broken when the
virtualenv path was longer than about 256 bytes (can't run a program
with a shebang longer than 256).

virtualenv's own method of making venvs relocatable does almost
what we want (uses a /usr/bin/env shebang and a "activate this"
snippet), but is too strict (only works on not-yet-moved virtualenvs,
while agent packages have already been moved).

This changeset adapts virtualenv's method, turning off the checking.

(while very long virtualenv names might be rare/nonexistent in practice,
some system tests have a test_id long enough to break because of this;
this fixes cosmo_tester.test_suites.test_blueprints.puppet_plugin_test
.PuppetPluginStandaloneTest.test_puppet_standalone_with_resource)