### PR TITLE
Properly quote RabbitMQ username and password

### DIFF
--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -21,6 +21,7 @@ import os
 import errno
 import getpass
 import types
+import urllib
 
 import pkg_resources
 from jinja2 import Template
@@ -191,8 +192,8 @@ class _Internal(object):
         broker_port = agent.get('broker_port', defaults.BROKER_PORT)
         broker_user = agent.get('broker_user', 'guest')
         broker_pass = agent.get('broker_pass', 'guest')
-        return defaults.BROKER_URL.format(username=broker_user,
-                                          password=broker_pass,
+        return defaults.BROKER_URL.format(username=urllib.quote(broker_user),
+                                          password=urllib.quote(broker_pass),
                                           host=broker_ip,
                                           port=broker_port)
 

--- a/cloudify_agent/tests/api/test_utils.py
+++ b/cloudify_agent/tests/api/test_utils.py
@@ -103,3 +103,9 @@ class TestUtils(BaseTest):
     def test_generate_agent_name(self):
         name = utils.internal.generate_agent_name()
         self.assertIn(defaults.CLOUDIFY_AGENT_PREFIX, name)
+
+    def test_get_broker_url(self):
+        config = dict(broker_ip='10.50.50.3', broker_port=4567,
+                      broker_user='us#er', broker_pass='pa$$word')
+        self.assertEqual('amqp://us%23er:pa%24%24word@10.50.50.3:4567//',
+                         utils.internal.get_broker_url(config))


### PR DESCRIPTION
If username or password for RabbitMQ contained any characters that
need to be escaped when present in URL, bootstrap procedure failed
when trying to start management worker.

This commit prevents such characters from making it into final broker
URL by properly quoting them.