### PR TITLE
CFY-5877 Raise exceptions on ssh prompts

### DIFF
--- a/cloudify_agent/installer/runners/fabric_runner.py
+++ b/cloudify_agent/installer/runners/fabric_runner.py
@@ -38,6 +38,8 @@ COMMON_ENV = {
     'warn_only': True,
     'forward_agent': True,
     'abort_on_prompts': True,
+    # Raise Exception(message) instead of calling sys.exit(1)
+    'abort_exception': Exception,
     'disable_known_hosts': True
 }
 

--- a/cloudify_agent/tests/installer/runners/test_fabric_runner.py
+++ b/cloudify_agent/tests/installer/runners/test_fabric_runner.py
@@ -81,6 +81,7 @@ class TestValidations(BaseTest):
             host='host',
             user='password')
 
+
 @only_os('posix')
 class TestAbortException(BaseTest):
 


### PR DESCRIPTION
In this PR, fabric configuration is updated to raise exceptions instead of calling `sys.exit(1)` when ssh authentication fails.

This is useful because a more apropriate messsage is now written to logs:
> 2016-11-01 20:21:20.129  CFY <cloudify-nodecellar-example> [host_exm847.create] Task rescheduled 'cloudify_agent.installer.operations.create' -> Needed to prompt for a connection or sudo password (host: 172.20.0.3), but abort-on-prompts was set to True [retry 1]

Before this PR, the error message was just `1` which is what was passed to the `SystemExit` exception.