### PR TITLE
CFY-6380 Add quotes that were missing in service command

### DIFF
--- a/cloudify_agent/resources/pm/nssm/nssm.conf.template
+++ b/cloudify_agent/resources/pm/nssm/nssm.conf.template
@@ -10,14 +10,14 @@ echo Installing the agent as a windows service...
 --without-gossip ^
 --without-mingle ^
 --loglevel={{ log_level }} ^
---logfile={{ log_file }} ^
+--logfile="""{{ log_file }}""" ^
 --include=cloudify.dispatch ^
 --config=cloudify.broker_config ^
 -Ofair ^
 --with-gate-keeper ^
 --gate-keeper-bucket-size={{ max_workers }} ^
 --with-logging-server ^
---logging-server-logdir={{ workdir }}\logs
+--logging-server-logdir="""{{ workdir }}\logs"""
 
 if %errorlevel% neq 0 exit /b %errorlevel%
 


### PR DESCRIPTION
In this PR, some quotes that where missing around the service command have been added.

The changes have been successfully tested by runnnig the hello world example against a windows VM.