### PR TITLE
CFY 6381. Update storage directory default

### DIFF
--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -98,7 +98,7 @@ class _Internal(object):
             return cls.get_daemon_storage_dir()
         if username is None and cls.CLOUDIFY_DAEMON_USER_KEY in os.environ:
             username = cls.get_daemon_user()
-        return appdirs.user_data_dir('cloudify-agent', 'Cloudify')
+        return appdirs.site_data_dir('cloudify-agent', 'Cloudify')
 
     @staticmethod
     def generate_agent_name():

--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -26,6 +26,8 @@ import struct
 import array
 import operator
 
+import appdirs
+
 from jinja2 import Template
 
 from cloudify.context import BootstrapContext
@@ -96,7 +98,7 @@ class _Internal(object):
             return cls.get_daemon_storage_dir()
         if username is None and cls.CLOUDIFY_DAEMON_USER_KEY in os.environ:
             username = cls.get_daemon_user()
-        return os.path.join(get_home_dir(username), '.cfy-agent')
+        return appdirs.user_data_dir('cloudify-agent', 'Cloudify')
 
     @staticmethod
     def generate_agent_name():

--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -96,9 +96,13 @@ class _Internal(object):
         """
         if cls.CLOUDIFY_DAEMON_STORAGE_DIRECTORY_KEY in os.environ:
             return cls.get_daemon_storage_dir()
+
+        if os.name == 'nt':
+            return appdirs.site_data_dir('cloudify-agent', 'Cloudify')
+
         if username is None and cls.CLOUDIFY_DAEMON_USER_KEY in os.environ:
             username = cls.get_daemon_user()
-        return appdirs.site_data_dir('cloudify-agent', 'Cloudify')
+        return os.path.join(get_home_dir(username), '.cfy-agent')
 
     @staticmethod
     def generate_agent_name():

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     'cloudify-plugins-common==3.4.2',
     'cloudify-rest-client==3.4.2',
     'cloudify-script-plugin==1.4',
-    'appdirs==1.4.0',
+    'appdirs==1.4.2',
     'click==4.0',
     'celery==3.1.17',
     'jinja2==2.7.2',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ install_requires = [
     'cloudify-plugins-common==3.4.2',
     'cloudify-rest-client==3.4.2',
     'cloudify-script-plugin==1.4',
+    'appdirs==1.4.0',
     'click==4.0',
     'celery==3.1.17',
     'jinja2==2.7.2',


### PR DESCRIPTION
In this PR, the [`apddirs`](https://pypi.python.org/pypi/appdirs/1.4.0) library is used to get a directory to store cloudify agent data across different platforms.

In the test with windows, instead of using `C:\Users\Admin\.cfy-agent`, it now uses `C:\Users\cloudbase-init\AppData\Local\Cloudify\cloudify-agent`