### PR TITLE
CFY 6382. Set service display name and description (port to 4.0)

### DIFF
--- a/cloudify_agent/resources/pm/nssm/nssm.conf.template
+++ b/cloudify_agent/resources/pm/nssm/nssm.conf.template
@@ -45,6 +45,8 @@ CELERY_APP=cloudify_agent.app.app ^
 CELERY_TASK_SERIALIZER=json ^
 CELERY_RESULT_SERIALIZER=json ^ {{ custom_environment }}
 
+{{ nssm_path }} set {{ name }} DisplayName "Cloudify Agent - {{ name }}"
+
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo Configuring startup policy...

--- a/cloudify_agent/resources/pm/nssm/nssm.conf.template
+++ b/cloudify_agent/resources/pm/nssm/nssm.conf.template
@@ -46,6 +46,7 @@ CELERY_TASK_SERIALIZER=json ^
 CELERY_RESULT_SERIALIZER=json ^ {{ custom_environment }}
 
 {{ nssm_path }} set {{ name }} DisplayName "Cloudify Agent - {{ name }}"
+{{ nssm_path }} set {{ name }} Description "Cloudify Agent Service"
 
 if %errorlevel% neq 0 exit /b %errorlevel%
 


### PR DESCRIPTION
In this PR, the cloudify agent service configuration is updated to set the display name and description. The name is still the same, so this doesn't affect any command, just the representation of the service in the GUI:

![screenshot from 2017-02-22 09-59-49](https://cloud.githubusercontent.com/assets/43780/23204280/3bc46730-f8e6-11e6-8823-1a9c19b30f5d.png)

Port of: #208