### PR TITLE
CFY 6382. Add service_name property

### DIFF
--- a/cloudify_agent/installer/config/attributes.py
+++ b/cloudify_agent/installer/config/attributes.py
@@ -84,6 +84,9 @@ AGENT_ATTRIBUTES = {
     'name': {
         'group': 'cfy-agent'
     },
+    'service_name': {
+        'group': 'cfy-agent'
+    },
     'process_management': {
         'group': 'cfy-agent'
     },

--- a/cloudify_agent/installer/config/configuration.py
+++ b/cloudify_agent/installer/config/configuration.py
@@ -156,6 +156,11 @@ def _cfy_agent_attributes_no_defaults(cloudify_agent):
             name = ctx.instance.id
         cloudify_agent['name'] = name
 
+    service_name = cloudify_agent.get('service_name')
+    if service_name:
+        # service_name takes precedence over name (which is deprecated)
+        cloudify_agent['name'] = service_name
+
     if not cloudify_agent.get('queue'):
         # by default, the queue of the agent is the same as the name
         cloudify_agent['queue'] = cloudify_agent['name']

--- a/cloudify_agent/tests/test_operations.py
+++ b/cloudify_agent/tests/test_operations.py
@@ -41,9 +41,10 @@ from cloudify_agent.tests.api.pm import BaseDaemonLiveTestCase
 from cloudify_agent.tests.api.pm import only_ci
 
 
-_INSTALL_SCRIPT_URL = ('https://raw.githubusercontent.com/cloudify-cosmo/'
-                       'cloudify-manager/master/resources/'
-                       'rest-service/cloudify/install_agent.py')
+_INSTALL_SCRIPT_URL = (
+    'https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/'
+    '3.4.2-build/resources/rest-service/cloudify/install_agent.py'
+)
 
 
 class _MockManagerClient(object):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requires = [
     'cloudify-plugins-common==3.4.2',
     'cloudify-rest-client==3.4.2',
     'cloudify-script-plugin==1.4',
-    'appdirs==1.4.2',
+    'appdirs==1.4.3',
     'click==4.0',
     'celery==3.1.17',
     'jinja2==2.7.2',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,4 @@ FileServer
 https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/3.4.2.zip
 
 # for creating the agent package in tests
-https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/3.4.2.zip
+https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/master.zip


### PR DESCRIPTION
In this PR, the `service_name` property is added to the agent.

The change has been verified using the hello world example templates for openstack in both windows and linux. The values tested have been strings without spaces because from what I've seen service names follow these patterns:
- Linux: `service_name`
- Windows: `ServiceName`

so I'd recommend using them.

Note: given that `cloudify_manager['name']` is used in multiple places, the easiest and less risky way to apply the change is to set `cloudify_manager['name']` to `cloudify_manager['service_name']` rather than changing every occurrence of `name` to use `service_name` in the code.