### PR TITLE
CFY 6382. Add service_name property (port to 4.0)

### DIFF
--- a/cloudify_agent/installer/config/attributes.py
+++ b/cloudify_agent/installer/config/attributes.py
@@ -88,6 +88,9 @@ AGENT_ATTRIBUTES = {
     'name': {
         'group': 'cfy-agent'
     },
+    'service_name': {
+        'group': 'cfy-agent'
+    },
     'process_management': {
         'group': 'cfy-agent'
     },

--- a/cloudify_agent/installer/config/configuration.py
+++ b/cloudify_agent/installer/config/configuration.py
@@ -154,6 +154,11 @@ def _cfy_agent_attributes_no_defaults(cloudify_agent):
             name = ctx.instance.id
         cloudify_agent['name'] = name
 
+    service_name = cloudify_agent.get('service_name')
+    if service_name:
+        # service_name takes precedence over name (which is deprecated)
+        cloudify_agent['name'] = service_name
+
     if not cloudify_agent.get('queue'):
         # by default, queue of the agent is the same as the name
         cloudify_agent['queue'] = cloudify_agent['name']


### PR DESCRIPTION
In this PR, the `service_name` property is added to the agent.

Port of: #219 