### PR TITLE
CFY-6380 Add quotes around cfy-agent path

### DIFF
--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -49,7 +49,7 @@ class AgentInstaller(object):
         if execution_env is None:
             execution_env = {}
         response = self.runner.run(
-            command='{0} {1}'.format(self.cfy_agent_path, command),
+            command='"{0}" {1}'.format(self.cfy_agent_path, command),
             execution_env=execution_env)
         output = response.std_out
         if output:

--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -48,6 +48,8 @@ class AgentInstaller(object):
     def run_agent_command(self, command, execution_env=None):
         if execution_env is None:
             execution_env = {}
+
+        # TBD: Investigate why adding quotes don't work on linux
         if self.cloudify_agent.get('windows', False):
             full_command = '"{0}" {1}'
         else:

--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -48,8 +48,12 @@ class AgentInstaller(object):
     def run_agent_command(self, command, execution_env=None):
         if execution_env is None:
             execution_env = {}
+        if self.cloudify_agent.get('windows', False):
+            full_command = '"{0}" {1}'
+        else:
+            full_command = '{0} {1}'
         response = self.runner.run(
-            command='"{0}" {1}'.format(self.cfy_agent_path, command),
+            command=full_command.format(self.cfy_agent_path, command),
             execution_env=execution_env)
         output = response.std_out
         if output:


### PR DESCRIPTION
In this PR, quotes around `cfy-agent` path are added to take into account the case in which it contains spaces.