### PR TITLE
Always upgrade packages in tox virtualenvs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,8 @@ dependencies:
         tox -e py26 --notest
         tox -e py27 --notest
         ;;
+      *)
+        echo "Not running in first node. Skipping."
       esac
   cache_directories:
     - ~/.cache/pip

--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,7 @@ dependencies:
         ;;
       esac
   cache_directories:
+    - ~/.cache/pip
     - .tox
 
 test:

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@
 envlist=flake8,docs,py27,py26
 
 [testenv]
+install_command = pip install -U {opts} {packages}
 deps =
     coverage==3.7.1
     nose


### PR DESCRIPTION
In this PR, the `install_command` used in tox configuration files is updated to include the `-U` flag. This should take care of the case in which a cloudify package has been cached in a tox virtualenv, but it's been updated later by pushing a new change to github using the same version number.

Related: cloudify-cosmo/cloudify-manager#761