### PR TITLE
Make sure errors are reported in CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,7 @@ dependencies:
     - pip install -U pip
     - pip install tox
     - |
+      set -e
       case $CIRCLE_NODE_INDEX in
       0)
         tox -e py26 --notest
@@ -32,6 +33,7 @@ dependencies:
 test:
   override:
     - ? |
+        set -e
         case $CIRCLE_NODE_INDEX in
         0)
           tox -e py27


### PR DESCRIPTION
When I updated `circle.yml` recently, I introduced a problem as a result of joining multiple commands in the same case statement. The problem is that if a command before the last one fails, then its error code is lost and CircleCI reports the tests as passed.

In this PR, the problem is fixed by adding `set -e` when multiple commands are executed. This needs to be added multiple times because CircleCI uses a different shell each time.