### PR TITLE
Skip running tests for a branch when PR is open

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+# Do not build feature branch with open Pull Requests
+skip_branch_with_pr: true
+
 environment:
 
   TOX_ENV: pywin


### PR DESCRIPTION
This is because another test run happens with the contents of the PR
after being merged which is what is more interesting to know.