### PR TITLE
CFY 6380. Add missing quotes for winrm scenario

### DIFF
--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -49,7 +49,7 @@ class AgentInstaller(object):
         if execution_env is None:
             execution_env = {}
 
-        # TBD: Investigate why adding quotes don't work on linux
+        # TBD: Investigate why adding quotes doesn't work on linux
         if self.cloudify_agent.get('windows', False):
             full_command = '"{0}" {1}'
         else:

--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -349,7 +349,7 @@ class WindowsInstallerMixin(AgentInstaller):
         self.logger.debug('Extracting {0} to {1}'
                           .format(archive, destination))
         cmd = '{0} /SILENT /VERYSILENT' \
-              ' /SUPPRESSMSGBOXES /DIR={1}'.format(archive, destination)
+              ' /SUPPRESSMSGBOXES /DIR="{1}"'.format(archive, destination)
         self.runner.run(cmd)
         return destination
 

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -242,7 +242,7 @@ class WinRMRunner(object):
         """
 
         return self.run(
-            '''@powershell -Command "Remove-Item -Recurse -Force {0}"'''
+            """@powershell -Command 'Remove-Item -Recurse -Force "{0}"'"""
             .format(path), raise_on_failure=not ignore_missing)
 
     def mktemp(self):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,4 @@ FileServer
 https://github.com/cloudify-cosmo/cloudify-dsl-parser/archive/3.4.2.zip
 
 # for creating the agent package in tests
-https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/3.4.2.zip
+https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/master.zip


### PR DESCRIPTION
In this PR, a couple of quotes related to the installation of the cloudify agent on windows using winrm have been added to support paths with spaces.