### PR TITLE
CFY 6380. Add missing quotes for winrm scenario (port to 4.0)

### DIFF
--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -298,7 +298,7 @@ class WindowsInstallerMixin(AgentInstaller):
         self.logger.debug('Extracting {0} to {1}'
                           .format(archive, destination))
         cmd = '{0} /SILENT /VERYSILENT' \
-              ' /SUPPRESSMSGBOXES /DIR={1}'.format(archive, destination)
+              ' /SUPPRESSMSGBOXES /DIR="{1}"'.format(archive, destination)
         self.runner.run(cmd)
         return destination
 

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -257,7 +257,7 @@ class WinRMRunner(object):
         """
 
         return self.run(
-            '''@powershell -Command "Remove-Item -Recurse -Force {0}"'''
+            """@powershell -Command 'Remove-Item -Recurse -Force "{0}"'"""
             .format(path), raise_on_failure=not ignore_missing)
 
     def mktemp(self):


### PR DESCRIPTION
In this PR, a couple of quotes related to the installation of the cloudify agent on windows using winrm have been added to support paths with spaces.