### PR TITLE
Quote cfy agent path

### DIFF
--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -273,7 +273,7 @@ class WindowsInstallerMixin(AgentInstaller):
 
     @property
     def cfy_agent_path(self):
-        return '{0}\\Scripts\\cfy-agent'.format(
+        return '"{0}\\Scripts\\cfy-agent"'.format(
             self.cloudify_agent['envdir'])
 
     def install_pip(self):
@@ -307,7 +307,7 @@ class LinuxInstallerMixin(AgentInstaller):
 
     @property
     def cfy_agent_path(self):
-        return '{0}/bin/python {0}/bin/cfy-agent'.format(
+        return '"{0}/bin/python" "{0}/bin/cfy-agent"'.format(
             self.cloudify_agent['envdir'])
 
     def install_pip(self):

--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -41,14 +41,8 @@ class AgentInstaller(object):
     def run_agent_command(self, command, execution_env=None):
         if execution_env is None:
             execution_env = {}
-
-        # TBD: Investigate why adding quotes doesn't work on linux
-        if self.cloudify_agent.get('windows', False):
-            full_command = '"{0}" {1}'
-        else:
-            full_command = '{0} {1}'
         response = self.runner.run(
-            command=full_command.format(self.cfy_agent_path, command),
+            command='{0} {1}'.format(self.cfy_agent_path, command),
             execution_env=execution_env)
         output = response.std_out
         if output:


### PR DESCRIPTION
This is a small refactoring to quote the cfy agent path both on windows and linux.

Related: #234 