### PR TITLE
CFY-6577 Fix agents upgrade after snapshot restore

### DIFF
--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -79,10 +79,6 @@ class AgentInstaller(object):
             )
         )
         self.runner.put_file(src=local_cert_path, dst=remote_cert_path)
-        self.logger.info(
-            'Passing broker SSL certificate from {0}'.format(local_cert_path))
-        with open(local_cert_path) as cert_file:
-            self.cloudify_agent['broker_ssl_cert'] = cert_file.read()
 
     def _get_local_ssl_cert_path(self):
         default_path = os.environ[env.CLOUDIFY_LOCAL_REST_CERT_PATH]

--- a/cloudify_agent/installer/config/attributes.py
+++ b/cloudify_agent/installer/config/attributes.py
@@ -82,6 +82,9 @@ AGENT_ATTRIBUTES = {
     'broker_ssl_cert_path': {
         'group': 'cfy-agent'
     },
+    'broker_ssl_cert': {
+        'group': 'cfy-agent'
+    },
     'queue': {
         'group': 'cfy-agent'
     },

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -196,7 +196,7 @@ def _celery_client(ctx, agent):
         'BROKER_URL': broker_url,
         'CELERY_RESULT_BACKEND': broker_url
     }
-    if not ManagerVersion(agent['version']).equals(ManagerVersion('3.2')):
+    if ManagerVersion(agent['version']) != ManagerVersion('3.2'):
         config['CELERY_TASK_RESULT_EXPIRES'] = \
             defaults.CELERY_TASK_RESULT_EXPIRES
     fd, cert_path = tempfile.mkstemp()
@@ -219,8 +219,7 @@ def _celery_client(ctx, agent):
 
 
 def _celery_task_name(version):
-    if not version or ManagerVersion(version).greater_than(
-            ManagerVersion('3.3.1')):
+    if not version or ManagerVersion(version) > ManagerVersion('3.3.1'):
         return 'cloudify.dispatch.dispatch'
     else:
         return 'script_runner.tasks.run'

--- a/cloudify_agent/shell/commands/installer.py
+++ b/cloudify_agent/shell/commands/installer.py
@@ -30,12 +30,15 @@ from cloudify_agent.installer.operations import prepare_local_installer
               type=click.File())
 @click.option('--output-agent-file',
               help='Path to output agent configuration')
+@click.option('--rest-token',
+              help='The rest token with which to download the package')
 @handle_failures
-def install_local(agent_file, output_agent_file):
+def install_local(agent_file, output_agent_file, rest_token):
     if agent_file is None:
         raise click.ClickException('--agent-file should be specified.')
     cloudify_agent = json.load(agent_file)
-    state.current_ctx.set(context.CloudifyContext, {})
+    ctx = context.CloudifyContext({'rest_token': rest_token})
+    state.current_ctx.set(ctx, {})
     if not cloudify_agent.get('rest_port'):
         cloudify_agent['rest_port'] = defaults.INTERNAL_REST_PORT
     os.environ[utils.internal.CLOUDIFY_DAEMON_USER_KEY] = str(

--- a/cloudify_agent/tests/__init__.py
+++ b/cloudify_agent/tests/__init__.py
@@ -83,7 +83,8 @@ class BaseTest(unittest.TestCase):
         constants.REST_PORT_KEY: '80',
         constants.BROKER_SSL_CERT_PATH: 'broker/cert/path',
         env_constants.CLOUDIFY_LOCAL_REST_CERT_PATH: tmp_rest_cert_path,
-        env_constants.CLOUDIFY_BROKER_SSL_CERT_PATH: 'broker/cert/path'
+        env_constants.CLOUDIFY_BROKER_SSL_CERT_PATH: 'broker/cert/path',
+        constants.MANAGER_FILE_SERVER_ROOT_KEY: 'localhost/resources'
     }
 
     def setUp(self):

--- a/cloudify_agent/tests/test_operations.py
+++ b/cloudify_agent/tests/test_operations.py
@@ -43,11 +43,9 @@ from cloudify_agent.tests.api.pm import only_ci
 
 
 _AGENT_SCRIPT_NAME = 'install_agent_template.py'
-# TODO: Change back to master
 _INSTALL_SCRIPT_URL = ('https://raw.githubusercontent.com/cloudify-cosmo/'
-                       'cloudify-manager/'
-                       'CFY-6577-fix-agents-upgrade/resources/'
-                       'rest-service/cloudify/{0}'.format(_AGENT_SCRIPT_NAME))
+                       'cloudify-manager/4.0/resources/rest-service/'
+                       'cloudify/{0}'.format(_AGENT_SCRIPT_NAME))
 
 
 class _MockManagerClient(object):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/cloudify-cosmo/cloudify-rest-client/archive/4.0.zip
-https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/4.0.zip
+https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/CFY-6577-fix-agents-upgrade.zip
 https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.4.zip
 # The Diamond plugin is not included as a dependency in the setup.py since it breaks
 # backwards compatibility with blueprints that require using an older version of the diamond-plugin.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 https://github.com/cloudify-cosmo/cloudify-rest-client/archive/4.0.zip
-https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/CFY-6577-fix-agents-upgrade.zip
+https://github.com/cloudify-cosmo/cloudify-plugins-common/archive/4.0.zip
 https://github.com/cloudify-cosmo/cloudify-script-plugin/archive/1.4.zip
 # The Diamond plugin is not included as a dependency in the setup.py since it breaks
 # backwards compatibility with blueprints that require using an older version of the diamond-plugin.


### PR DESCRIPTION
The new agents upgrade process is as follows:
 * Upon issue of a `cfy agents install` command, a new
   `install_agent.py` script is rendered, with a REST token and the SSL
   certificate inside it.
 * It is then moved to a special location inside the file server
   (/resources/cloudify_agent), with a fresh UUID prepended to it.
 * The request is sent to the celery client on the agent machine,
   and processed by the worker thread there (this is as it was before)
 * The old agent downloads the script, which holds all the info
   necessary to update the SSL certificate, and then proceed to
   download and install the new agent package, as before