### PR TITLE
Run mkdir through powershell

### DIFF
--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -291,7 +291,7 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         :rtype WinRMCommandExecutionResponse.
         """
 
-        return self.run('mkdir \"{0}\" -Force'.format(path))
+        return self.run('mkdir \"{0}\" -Force'.format(path), powershell=True)
 
     def new_file(self, path):
 


### PR DESCRIPTION
This is because the `-Force` flag is not recognized by cmd, so the
command needs to be executed through powershell to avoid getting errors
if the command is executed multiple times.