### PR TITLE
CFY-6577 Fix `cfy agents install` for 3.4.2 snapshots

### DIFF
--- a/cloudify_agent/tests/__init__.py
+++ b/cloudify_agent/tests/__init__.py
@@ -26,7 +26,6 @@ from cloudify import constants, mocks
 from cloudify.state import current_ctx
 from cloudify.utils import setup_logger
 
-import cloudify_agent.shell.env as env_constants
 from cloudify_agent.api.defaults import (SSL_CERTS_TARGET_DIR,
                                          AGENT_SSL_CERT_FILENAME)
 
@@ -81,7 +80,7 @@ class BaseTest(unittest.TestCase):
             constants.REST_HOST_KEY: 'localhost',
             constants.REST_PORT_KEY: '80',
             constants.BROKER_SSL_CERT_PATH: self._rest_cert_path,
-            env_constants.CLOUDIFY_LOCAL_REST_CERT_PATH: self._rest_cert_path,
+            constants.LOCAL_REST_CERT_FILE_KEY: self._rest_cert_path,
             constants.MANAGER_FILE_SERVER_ROOT_KEY: 'localhost/resources'
         }
 
@@ -96,18 +95,23 @@ class BaseTest(unittest.TestCase):
         for key, value in agent_env_vars.iteritems():
             os.environ[key] = value
 
-        def clean_temp_folder():
+        def clean_folder(folder_name):
             try:
-                shutil.rmtree(self.temp_folder)
+                shutil.rmtree(folder_name)
             except win_error:
                 # no hard feeling if file is locked.
                 pass
+
+        def clean_storage_dir():
+            if os.path.exists(get_storage_directory()):
+                clean_folder(get_storage_directory())
 
         def clean_env():
             for var in agent_env_vars.iterkeys():
                 del os.environ[var]
 
-        self.addCleanup(clean_temp_folder)
+        self.addCleanup(clean_folder, folder_name=self.temp_folder)
+        self.addCleanup(clean_storage_dir)
         self.addCleanup(clean_env)
         os.chdir(self.temp_folder)
         self.addCleanup(lambda: os.chdir(self.curr_dir))

--- a/cloudify_agent/tests/api/pm/__init__.py
+++ b/cloudify_agent/tests/api/pm/__init__.py
@@ -31,9 +31,9 @@ from cloudify_agent.api import utils, defaults
 from cloudify_agent.api import exceptions
 from cloudify_agent.api.plugins.installer import PluginInstaller
 
+from cloudify_agent.tests import BaseTest
 from cloudify_agent.tests import resources
 from cloudify_agent.tests import utils as test_utils
-from cloudify_agent.tests import BaseTest, agent_ssl_cert
 
 
 BUILT_IN_TASKS = [
@@ -198,7 +198,6 @@ class BaseDaemonProcessManagementTest(BaseDaemonLiveTestCase):
 
     def create_daemon(self, **attributes):
         name = utils.internal.generate_agent_name()
-        local_rest_cert_file = agent_ssl_cert.get_local_cert_path()
 
         params = {
             'rest_host': '127.0.0.1',
@@ -208,7 +207,7 @@ class BaseDaemonProcessManagementTest(BaseDaemonLiveTestCase):
             'logger': self.logger,
             'name': name,
             'queue': '{0}-queue'.format(name),
-            'local_rest_cert_file': local_rest_cert_file,
+            'local_rest_cert_file': self._rest_cert_path,
             'broker_ssl_enabled': False
         }
         params.update(attributes)

--- a/cloudify_agent/tests/api/pm/test_base.py
+++ b/cloudify_agent/tests/api/pm/test_base.py
@@ -20,7 +20,7 @@ from cloudify_agent.api.pm.base import Daemon
 from cloudify_agent.api import exceptions
 
 from cloudify_agent.tests import BaseTest
-from cloudify_agent.tests import get_storage_directory, agent_ssl_cert
+from cloudify_agent.tests import get_storage_directory
 
 
 @patch('cloudify_agent.api.utils.internal.get_storage_directory',
@@ -36,7 +36,7 @@ class TestDaemonDefaults(BaseTest):
             name='name',
             broker_user='guest',
             broker_pass='guest',
-            local_rest_cert_file=agent_ssl_cert.get_local_cert_path()
+            local_rest_cert_file=self._rest_cert_path
         )
 
     def test_default_workdir(self):
@@ -72,7 +72,7 @@ class TestDaemonValidations(BaseTest):
                 user='user',
                 broker_user='guest',
                 broker_pass='guest',
-                local_rest_cert_file=agent_ssl_cert.get_local_cert_path()
+                local_rest_cert_file=self._rest_cert_path
             )
             self.fail('Expected ValueError due to missing rest_host')
         except exceptions.DaemonMissingMandatoryPropertyError as e:
@@ -90,7 +90,7 @@ class TestDaemonValidations(BaseTest):
                 min_workers='bad',
                 broker_user='guest',
                 broker_pass='guest',
-                local_rest_cert_file=agent_ssl_cert.get_local_cert_path()
+                local_rest_cert_file=self._rest_cert_path
             )
         except exceptions.DaemonPropertiesError as e:
             self.assertTrue('min_workers is supposed to be a number' in
@@ -108,7 +108,7 @@ class TestDaemonValidations(BaseTest):
                 max_workers='bad',
                 broker_user='guest',
                 broker_pass='guest',
-                local_rest_cert_file=agent_ssl_cert.get_local_cert_path()
+                local_rest_cert_file=self._rest_cert_path
             )
         except exceptions.DaemonPropertiesError as e:
             self.assertTrue('max_workers is supposed to be a number' in
@@ -127,7 +127,7 @@ class TestDaemonValidations(BaseTest):
                 min_workers=5,
                 broker_user='guest',
                 broker_pass='guest',
-                local_rest_cert_file=agent_ssl_cert.get_local_cert_path()
+                local_rest_cert_file=self._rest_cert_path
             )
         except exceptions.DaemonPropertiesError as e:
             self.assertTrue('min_workers cannot be greater than max_workers'
@@ -138,16 +138,16 @@ class TestDaemonValidations(BaseTest):
        get_storage_directory)
 class TestNotImplemented(BaseTest):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.daemon = Daemon(
+    def setUp(self):
+        super(TestNotImplemented, self).setUp()
+        self.daemon = Daemon(
             rest_host='127.0.0.1',
             broker_ip='127.0.0.1',
             name='name',
             queue='queue',
             broker_user='guest',
             broker_pass='guest',
-            local_rest_cert_file=agent_ssl_cert.get_local_cert_path()
+            local_rest_cert_file=self._rest_cert_path
         )
 
     def test_start_command(self):

--- a/cloudify_agent/tests/api/test_factory.py
+++ b/cloudify_agent/tests/api/test_factory.py
@@ -20,11 +20,10 @@ import shutil
 from cloudify_agent.api import exceptions
 from cloudify_agent.api import utils
 from cloudify_agent.api.factory import DaemonFactory
-from cloudify_agent.tests.shell import BaseShellTest
-from cloudify_agent.tests import get_storage_directory
+from cloudify_agent.tests import get_storage_directory, BaseTest
 
 
-class TestDaemonFactory(BaseShellTest):
+class TestDaemonFactory(BaseTest):
 
     def setUp(self):
         super(TestDaemonFactory, self).setUp()

--- a/cloudify_agent/tests/api/test_factory.py
+++ b/cloudify_agent/tests/api/test_factory.py
@@ -21,7 +21,7 @@ from cloudify_agent.api import exceptions
 from cloudify_agent.api import utils
 from cloudify_agent.api.factory import DaemonFactory
 from cloudify_agent.tests.shell import BaseShellTest
-from cloudify_agent.tests import get_storage_directory, agent_ssl_cert
+from cloudify_agent.tests import get_storage_directory
 
 
 class TestDaemonFactory(BaseShellTest):
@@ -30,7 +30,6 @@ class TestDaemonFactory(BaseShellTest):
         super(TestDaemonFactory, self).setUp()
         self.daemon_name = 'test-daemon-{0}'.format(uuid.uuid4())
         self.factory = DaemonFactory(storage=get_storage_directory())
-        self.local_rest_cert_file = agent_ssl_cert.get_local_cert_path()
 
     def test_new_initd(self):
         daemon = self.factory.new(
@@ -41,7 +40,7 @@ class TestDaemonFactory(BaseShellTest):
             broker_ip='127.0.0.1',
             user='user',
             broker_url='127.0.0.1',
-            local_rest_cert_file=self.local_rest_cert_file
+            local_rest_cert_file=self._rest_cert_path
         )
         self.assertEqual(self.daemon_name, daemon.name)
         self.assertEqual('queue', daemon.queue)
@@ -49,7 +48,7 @@ class TestDaemonFactory(BaseShellTest):
         self.assertEqual('amqp://guest:guest@127.0.0.1:5671//',
                          daemon.broker_url)
         self.assertEqual('user', daemon.user)
-        self.assertEqual(self.local_rest_cert_file,
+        self.assertEqual(self._rest_cert_path,
                          daemon.local_rest_cert_file)
 
     def test_new_no_implementation(self):
@@ -67,7 +66,7 @@ class TestDaemonFactory(BaseShellTest):
             broker_ip='127.0.0.1',
             user='user',
             broker_url='127.0.0.1',
-            local_rest_cert_file=self.local_rest_cert_file
+            local_rest_cert_file=self._rest_cert_path
         )
 
         self.factory.save(daemon)
@@ -99,7 +98,7 @@ class TestDaemonFactory(BaseShellTest):
                 broker_ip='127.0.0.1',
                 user='user',
                 broker_url='127.0.0.1',
-                local_rest_cert_file=self.local_rest_cert_file
+                local_rest_cert_file=self._rest_cert_path
             )
             self.factory.save(daemon)
 
@@ -126,7 +125,7 @@ class TestDaemonFactory(BaseShellTest):
             broker_ip='127.0.0.1',
             user='user',
             broker_url='127.0.0.1',
-            local_rest_cert_file=self.local_rest_cert_file
+            local_rest_cert_file=self._rest_cert_path
         )
 
         self.factory.save(daemon)
@@ -140,4 +139,4 @@ class TestDaemonFactory(BaseShellTest):
                           broker_ip='127.0.0.1',
                           user='user',
                           broker_url='127.0.0.1',
-                          local_rest_cert_file=self.local_rest_cert_file)
+                          local_rest_cert_file=self._rest_cert_path)

--- a/cloudify_agent/tests/api/test_utils.py
+++ b/cloudify_agent/tests/api/test_utils.py
@@ -23,8 +23,8 @@ from cloudify_agent.api import utils
 from cloudify_agent.api import defaults
 from cloudify_agent.api.pm.base import Daemon
 
+from cloudify_agent.tests import BaseTest
 from cloudify_agent.tests import utils as test_utils
-from cloudify_agent.tests import BaseTest, agent_ssl_cert
 
 
 class TestUtils(BaseTest):
@@ -56,10 +56,9 @@ class TestUtils(BaseTest):
         self.assertEqual(expected, full_path)
 
     def test_daemon_to_dict(self):
-        local_rest_cert_file = agent_ssl_cert.get_local_cert_path()
         daemon = Daemon(rest_host='127.0.0.1', name='name',
                         queue='queue', broker_ip='127.0.0.1',
-                        local_rest_cert_file=local_rest_cert_file)
+                        local_rest_cert_file=self._rest_cert_path)
         daemon_json = utils.internal.daemon_to_dict(daemon)
         self.assertEqual(daemon_json['rest_host'], '127.0.0.1')
         self.assertEqual(daemon_json['broker_ip'], '127.0.0.1')

--- a/cloudify_agent/tests/installer/script/test_init_script.py
+++ b/cloudify_agent/tests/installer/script/test_init_script.py
@@ -51,7 +51,7 @@ class BaseInitScriptTest(BaseTest):
         self.addCleanup(lambda: current_ctx.clear())
         self.input_cloudify_agent = {
             'broker_ip': 'localhost',
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
 
     def _run(self, *commands):

--- a/cloudify_agent/tests/installer/test_operations.py
+++ b/cloudify_agent/tests/installer/test_operations.py
@@ -83,7 +83,7 @@ class AgentInstallerLocalTest(BaseDaemonLiveTestCase):
             'name': agent_name,
             'queue': agent_queue,
             'file_server_port': self.fs.port,
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
 
         env = local.init_env(name=self._testMethodName,
@@ -120,7 +120,7 @@ class AgentInstallerLocalTest(BaseDaemonLiveTestCase):
             'name': agent_name,
             'queue': agent_queue,
             'file_server_port': self.fs.port,
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
 
         env = local.init_env(name=self._testMethodName,
@@ -149,7 +149,7 @@ class AgentInstallerLocalTest(BaseDaemonLiveTestCase):
             'requirements_file': self.requirements_file,
             'name': agent_name,
             'queue': agent_queue,
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
 
         blueprint_path = resources.get_resource(
@@ -181,7 +181,7 @@ class AgentInstallerLocalTest(BaseDaemonLiveTestCase):
             'requirements_file': self.requirements_file,
             'name': agent_name,
             'queue': agent_queue,
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
 
         blueprint_path = resources.get_resource(
@@ -217,7 +217,7 @@ class AgentInstallerLocalTest(BaseDaemonLiveTestCase):
             'requirements_file': self.requirements_file,
             'name': agent_name,
             'queue': agent_queue,
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
 
         blueprint_path = resources.get_resource(

--- a/cloudify_agent/tests/shell/__init__.py
+++ b/cloudify_agent/tests/shell/__init__.py
@@ -12,36 +12,3 @@
 #  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
-
-import logging
-import tempfile
-import os
-
-from cloudify.utils import setup_logger
-
-from cloudify_agent.api import utils
-from cloudify_agent.tests import BaseTest
-
-
-class BaseShellTest(BaseTest):
-
-    def setUp(self):
-        super(BaseShellTest, self).setUp()
-        # Clear old handlers to avoid logging twice
-        for handler in self.logger.handlers:
-            self.logger.removeHandler(handler)
-        self.logger = setup_logger(
-            'cloudify-agent.tests.shell',
-            logger_level=logging.DEBUG)
-
-        utils.logger.setLevel(logging.DEBUG)
-
-        self.currdir = os.getcwd()
-        self.workdir = tempfile.mkdtemp(
-            prefix='cfy-agent-shell-tests-')
-        self.logger.info('Working directory: {0}'.format(self.workdir))
-        os.chdir(self.workdir)
-
-    def tearDown(self):
-        super(BaseShellTest, self).tearDown()
-        os.chdir(self.currdir)

--- a/cloudify_agent/tests/shell/__init__.py
+++ b/cloudify_agent/tests/shell/__init__.py
@@ -27,6 +27,9 @@ class BaseShellTest(BaseTest):
 
     def setUp(self):
         super(BaseShellTest, self).setUp()
+        # Clear old handlers to avoid logging twice
+        for handler in self.logger.handlers:
+            self.logger.removeHandler(handler)
         self.logger = setup_logger(
             'cloudify-agent.tests.shell',
             logger_level=logging.DEBUG)

--- a/cloudify_agent/tests/shell/commands/__init__.py
+++ b/cloudify_agent/tests/shell/commands/__init__.py
@@ -16,15 +16,15 @@
 import sys
 
 from cloudify_agent.shell import main as cli
-from cloudify_agent.tests.shell import BaseShellTest
+from cloudify_agent.tests import BaseTest
 
 
-class BaseCommandLineTestCase(BaseShellTest):
+class BaseCommandLineTestCase(BaseTest):
 
     def _run(self, command, raise_system_exit=False):
         sys.argv = command.split()
-        self.logger.info('Running cfy-agent command with sys.argv={'
-                         '0}'.format(sys.argv))
+        self.logger.info('Running cfy-agent command with '
+                         'sys.argv={0}'.format(sys.argv))
         try:
             cli.main()
         except SystemExit as e:

--- a/cloudify_agent/tests/shell/commands/test_install_local.py
+++ b/cloudify_agent/tests/shell/commands/test_install_local.py
@@ -52,8 +52,14 @@ class TestInstaller(BaseTest):
             agent_file.write(json.dumps(agent))
         _, output_path = tempfile.mkstemp()
         runner = LocalCommandRunner()
-        runner.run('cfy-agent install-local --agent-file {0} '
-                   '--output-agent-file {1}'.format(path, output_path))
+        runner.run(
+            'cfy-agent install-local --agent-file {0} '
+            '--output-agent-file {1} --rest-cert-path {2} '
+            '--rest-token TOKEN'.format(
+                path,
+                output_path,
+                self._rest_cert_path
+            ))
         self.assertTrue(inspect.active())
         with open(output_path) as new_agent_file:
             new_agent = json.loads(new_agent_file.read())
@@ -84,7 +90,7 @@ class TestInstaller(BaseTest):
             'windows': os.name == 'nt',
             'local': False,
             'broker_get_settings_from_manager': False,
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
         try:
             self._prepare_configuration(agent)
@@ -102,7 +108,7 @@ class TestInstaller(BaseTest):
             'windows': os.name == 'nt',
             'local': False,
             'broker_get_settings_from_manager': False,
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
         self._prepare_configuration(agent)
         self.assertNotIn('basedir', agent)

--- a/cloudify_agent/tests/test_operations.py
+++ b/cloudify_agent/tests/test_operations.py
@@ -43,10 +43,8 @@ from cloudify_agent.tests.api.pm import only_ci
 
 
 _AGENT_SCRIPT_NAME = 'install_agent_template.py'
-# TODO: Change branch to 4.0 before merge
 _INSTALL_SCRIPT_URL = ('https://raw.githubusercontent.com/cloudify-cosmo/'
-                       'cloudify-manager/CFY-6577-fix-agents-install-3.4/'
-                       'resources/rest-service/'
+                       'cloudify-manager/4.0/resources/rest-service/'
                        'cloudify/{0}'.format(_AGENT_SCRIPT_NAME))
 
 

--- a/cloudify_agent/tests/test_operations.py
+++ b/cloudify_agent/tests/test_operations.py
@@ -43,8 +43,10 @@ from cloudify_agent.tests.api.pm import only_ci
 
 
 _AGENT_SCRIPT_NAME = 'install_agent_template.py'
+# TODO: Change branch to 4.0 before merge
 _INSTALL_SCRIPT_URL = ('https://raw.githubusercontent.com/cloudify-cosmo/'
-                       'cloudify-manager/4.0/resources/rest-service/'
+                       'cloudify-manager/CFY-6577-fix-agents-install-3.4/'
+                       'resources/rest-service/'
                        'cloudify/{0}'.format(_AGENT_SCRIPT_NAME))
 
 
@@ -111,7 +113,7 @@ class TestInstallNewAgent(BaseDaemonLiveTestCase):
         self.logger.info('Initiating local env')
         inputs = {
             'name': agent_name,
-            'ssl_cert_path': agent_ssl_cert.get_local_cert_path()
+            'ssl_cert_path': self._rest_cert_path
         }
 
         # Necessary to patch this method, because by default port 80 is used

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ deps =
     testfixtures
     -rdev-requirements.txt
     -rtest-requirements.txt
-commands=nosetests -s cloudify_agent/tests {posargs}
+# TODO: Change back before merging
+commands=nosetests -s -v cloudify_agent/tests/ {posargs}
 passenv=TRAVIS_BUILD_DIR CIRCLE_BUILD_NUM
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     testfixtures
     -rdev-requirements.txt
     -rtest-requirements.txt
-# TODO: Change back before merging
 commands=nosetests -s -v cloudify_agent/tests/ {posargs}
 passenv=TRAVIS_BUILD_DIR CIRCLE_BUILD_NUM
 


### PR DESCRIPTION
As the `install_agent.py` script runs on the old mgmtworker env, it
might not have the new `local_rest_cert_path` function, so we pass it
directly in the script