### PR TITLE
CFY-6843 Change initd service name per daemon

### DIFF
--- a/cloudify_agent/api/pm/initd.py
+++ b/cloudify_agent/api/pm/initd.py
@@ -107,7 +107,8 @@ class GenericLinuxDaemon(CronRespawnDaemon):
         rendered = utils.render_template_to_file(
             template_path='pm/initd/initd.template',
             daemon_name=self.name,
-            config_path=self.config_path
+            config_path=self.config_path,
+            service_name=self.service_name
         )
         self._runner.run('sudo mkdir -p {0}'.format(
             os.path.dirname(self.script_path)))

--- a/cloudify_agent/resources/pm/initd/initd.template
+++ b/cloudify_agent/resources/pm/initd/initd.template
@@ -10,7 +10,7 @@
 
 
 ### BEGIN INIT INFO
-# Provides:          celeryd
+# Provides:          {{ service_name }}
 # Required-Start:    $network $local_fs $remote_fs
 # Required-Stop:     $network $local_fs $remote_fs
 # Default-Start:     2 3 4 5


### PR DESCRIPTION
Instead of hardcoding the service name "celeryd", let's use
a different service name for each agent. This allows installing
more than one agent on systems that check that name
(eg. ubuntu 16.04)