### PR TITLE
CFY-6990 Explicitly set paramiko's version, to avoid pynacl trouble

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     'jinja2==2.7.2',
     'pywinrm==0.0.3',
     'fabric==1.13.1',
+    'paramiko==2.1.2',
     'wagon==0.3.2',
     'fasteners==0.13.0',
     'pyzmq==15.1.0',


### PR DESCRIPTION
In version 2.1.3 paramiko introduced pynacl as a dependency. We'd like
  to void that.