### PR TITLE
Agent install link

### DIFF
--- a/cloudify_agent/installer/operations.py
+++ b/cloudify_agent/installer/operations.py
@@ -22,7 +22,9 @@ from cloudify.exceptions import CommandExecutionError
 
 from cloudify_agent.api import utils
 
-from cloudify_agent.installer.script import get_init_script
+from cloudify_agent.installer.script import (
+    get_installer_script_downloader_script,
+)
 from .config.agent_config import create_agent_config_and_installer
 
 
@@ -34,7 +36,7 @@ def create(cloudify_agent, installer, **_):
     ctx.instance.runtime_properties['cloudify_agent'] = cloudify_agent
     ctx.instance.update()
 
-    script = get_init_script(cloudify_agent)
+    script = get_installer_script_downloader_script(cloudify_agent)
     with NamedTemporaryFile() as f:
         f.write(script)
         f.flush()

--- a/cloudify_agent/installer/operations.py
+++ b/cloudify_agent/installer/operations.py
@@ -22,9 +22,7 @@ from cloudify.exceptions import CommandExecutionError
 
 from cloudify_agent.api import utils
 
-from cloudify_agent.installer.script import (
-    get_installer_script_downloader_script,
-)
+from cloudify_agent.installer.script import get_init_script
 from .config.agent_config import create_agent_config_and_installer
 
 
@@ -36,7 +34,7 @@ def create(cloudify_agent, installer, **_):
     ctx.instance.runtime_properties['cloudify_agent'] = cloudify_agent
     ctx.instance.update()
 
-    script = get_installer_script_downloader_script(cloudify_agent)
+    script = get_init_script(cloudify_agent)
     with NamedTemporaryFile() as f:
         f.write(script)
         f.flush()

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -110,7 +110,8 @@ def get_install_script_download_link(cloudify_agent):
     file_server_root = get_manager_file_server_root()
     file_server_url = get_manager_file_server_url()
 
-    script_filename = '{}.py'.format(uuid.uuid4())
+    extension = 'ps1' if cloudify_agent['windows'] else 'sh'
+    script_filename = '{}.{}'.format(uuid.uuid4(), extension)
     # Store under cloudify_agent to avoid authentication
     script_relpath = os.path.join('cloudify_agent', script_filename)
     script_path = os.path.join(file_server_root, script_relpath)

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -81,33 +81,6 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         return self.custom_env_path
 
 
-def get_installer_script_downloader_script():
-    """Render a script that downloads the script that will install the agent.
-
-    A script to download the real script is needed, to avoid passing sensitive
-    data through user data.
-
-    """
-    resource = 'script/linux-download.sh.template'
-    template = jinja2.Template(utils.get_resource(resource))
-
-    file_server_root = get_manager_file_server_root()
-    file_server_url = get_manager_file_server_url()
-
-    script_filename = '{}.py'.format(uuid.uuid4())
-    script_relpath = os.path.join('cloudify_agent', script_filename)
-    script_path = os.path.join(file_server_root, script_relpath)
-    script_url = (
-        '{}/{}'.
-        format(file_server_url, script_relpath)
-    )
-    script_content = get_install_script()
-    with open(script_path, 'w') as script_file:
-        script_file.write(script_content)
-
-    return template.render(link=script_url)
-
-
 @create_agent_config_and_installer(validate_connection=False, new_agent=True)
 def init_script(cloudify_agent, **_):
     return get_install_script(cloudify_agent=cloudify_agent)

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -142,6 +142,9 @@ def get_init_script(cloudify_agent):
 
     """
     script_url = get_install_script_download_link(cloudify_agent)
-    resource = 'script/linux-download.sh.template'
+    if cloudify_agent['windows']:
+        resource = 'script/linux-download.sh.template'
+    else:
+        resource = 'script/windows-download.ps1.template'
     template = jinja2.Template(utils.get_resource(resource))
     return template.render(link=script_url)

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -20,12 +20,14 @@ import uuid
 from cloudify import ctx, utils as cloudify_utils
 from cloudify.constants import CLOUDIFY_TOKEN_AUTHENTICATION_HEADER
 
+from cloudify.utils import (
+    get_manager_file_server_root,
+    get_manager_file_server_url,
+)
 from cloudify_agent.api import utils
 from cloudify_agent.installer import AgentInstaller
 from cloudify_agent.installer.config.agent_config import \
     create_agent_config_and_installer
-
-from manager_rest.config import instance as config
 
 
 class AgentInstallationScriptBuilder(AgentInstaller):
@@ -89,12 +91,15 @@ def render_agent_installer_script_download_script():
     resource = 'script/linux-download.sh.template'
     template = jinja2.Template(utils.get_resource(resource))
 
+    file_server_root = get_manager_file_server_root()
+    file_server_url = get_manager_file_server_url()
+
     script_filename = '{}.py'.format(uuid.uuid4())
     script_relpath = os.path.join('cloudify_agent', script_filename)
-    script_path = os.path.join(config.file_server_root, script_relpath)
+    script_path = os.path.join(file_server_root, script_relpath)
     script_url = (
         '{}/{}'.
-        format(config.file_server_url, script_relpath)
+        format(file_server_url, script_relpath)
     )
     script_content = get_init_script()
     with open(script_path, 'w') as script_file:

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -81,7 +81,7 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         return self.custom_env_path
 
 
-def render_agent_installer_script_download_script():
+def get_installer_script_downloader_script():
     """Render a script that downloads the script that will install the agent.
 
     A script to download the real script is needed, to avoid passing sensitive

--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -15,4 +15,4 @@ download()
 }
 
 download
-./agent_intaller.sh
+./agent_installer.sh

--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+# Download and execute the script that will take care of the agent installation
+
+download()
+{
+    if command -v wget > /dev/null 2>&1; then
+        wget {{ link }} -O agent_installer.sh
+    elif command -v curl > /dev/null 2>&1; then
+        curl -L -o agent_installer.sh {{ link }}
+    else
+        echo >&2 "error: wget/curl not found. cannot download agent installation script"
+        return 1
+    fi
+}
+
+download
+./agent_intaller.sh

--- a/cloudify_agent/resources/script/windows-download.ps1.template
+++ b/cloudify_agent/resources/script/windows-download.ps1.template
@@ -1,0 +1,13 @@
+#ps1_sysnative
+
+function Download()
+{
+    # Make sure the output directory exists
+    New-Item -ItemType directory -Force -Path (Split-Path $OutputPath)
+
+    $WebClient = New-Object System.Net.WebClient
+    $WebClient.DownloadFile("{{ link }}", ".\agent_installer.ps1")
+}
+
+Download
+.\agent_installer.ps1


### PR DESCRIPTION
In this PR, the agent installation script functionality is updated to add an indirection step, that is, instead of generating a script that performs the agent installation, that script gets generated is together with another script that downloads the first one and executes it.