### PR TITLE
CFY-7124 Fix userdata script running sudo command without tty (#286)

### DIFF
--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -21,7 +21,8 @@ from contextlib import contextmanager
 from posixpath import join as url_join
 
 from cloudify import ctx, utils as cloudify_utils
-from cloudify.constants import CLOUDIFY_TOKEN_AUTHENTICATION_HEADER
+from cloudify.constants import (CLOUDIFY_TOKEN_AUTHENTICATION_HEADER,
+                                AGENT_INSTALL_METHOD_INIT_SCRIPT)
 
 from cloudify_agent.api import utils
 from cloudify_agent.installer import AgentInstaller
@@ -151,7 +152,14 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         template = jinja2.Template(
             utils.get_resource(self.init_script_template)
         )
-        return template.render(link=script_url)
+        use_sudo = self.cloudify_agent.get('install_with_sudo')
+        install_method = cloudify_utils.internal.get_install_method(
+            ctx.node.properties)
+        if use_sudo or install_method == AGENT_INSTALL_METHOD_INIT_SCRIPT:
+            sudo = 'sudo'
+        else:
+            sudo = ''
+        return template.render(link=script_url, sudo=sudo)
 
 
 @create_agent_config_and_installer(validate_connection=False,

--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -23,5 +23,5 @@ cd $(mktemp -d)
 
 download agent_installer.sh
 chmod +x ./agent_installer.sh
-sudo ./agent_installer.sh
+{{ sudo }} ./agent_installer.sh
 rm ./agent_installer.sh

--- a/cloudify_agent/tests/resources/blueprints/install-new-agent/install-new-agent-blueprint.yaml
+++ b/cloudify_agent/tests/resources/blueprints/install-new-agent/install-new-agent-blueprint.yaml
@@ -29,6 +29,7 @@ node_templates:
                 broker_ip: 127.0.0.1
               extra:
                 ssl_cert_path: { get_input: ssl_cert_path}
+                install_with_sudo: true
 
   validator:
     type: cloudify.nodes.Root


### PR DESCRIPTION
* CFY-7124 Fix userdata script running sudo command without tty

* CFY-7124 Allow users to pass an `install_with_sudo` extra param
By default, this shouldn't be relevant for users, but it might
become handy for provided installs (and tests)