### PR TITLE
CFY-7124 Make the `install_with_sudo` param mandatory

### DIFF
--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -21,8 +21,7 @@ from contextlib import contextmanager
 from posixpath import join as url_join
 
 from cloudify import ctx, utils as cloudify_utils
-from cloudify.constants import (CLOUDIFY_TOKEN_AUTHENTICATION_HEADER,
-                                AGENT_INSTALL_METHOD_INIT_SCRIPT)
+from cloudify.constants import CLOUDIFY_TOKEN_AUTHENTICATION_HEADER
 
 from cloudify_agent.api import utils
 from cloudify_agent.installer import AgentInstaller
@@ -153,12 +152,7 @@ class AgentInstallationScriptBuilder(AgentInstaller):
             utils.get_resource(self.init_script_template)
         )
         use_sudo = self.cloudify_agent.get('install_with_sudo')
-        install_method = cloudify_utils.internal.get_install_method(
-            ctx.node.properties)
-        if use_sudo or install_method == AGENT_INSTALL_METHOD_INIT_SCRIPT:
-            sudo = 'sudo'
-        else:
-            sudo = ''
+        sudo = 'sudo' if use_sudo else ''
         return template.render(link=script_url, sudo=sudo)
 
 

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -171,6 +171,7 @@ def _set_default_new_agent_config_values(old_agent, new_agent):
     new_agent['old_agent_version'] = old_agent['version']
     new_agent['remote_execution'] = True
     new_agent['disable_requiretty'] = False
+    new_agent['install_with_sudo'] = True
 
 
 def _copy_values_from_old_agent_config(old_agent, new_agent):


### PR DESCRIPTION
This is instead of inferring whether sudo is needed from the install
method.
The only 3 cases that use the `init_script` method are:
1. Regular userdata - in which case sudo is not needed
2. Agents upgrade - in which case the install method would be
   irrelevant in any case, and passing an argument would be necessary
3. System tests/other provided scenarios - in which case it is
   somewhat more flexible (and up to the user) to require providing
   the argument