### PR TITLE
CFY-7142. Fix command line too long (port to 4.2)

### DIFF
--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -398,7 +398,7 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         :rtype WinRMCommandExecutionResponse.
         """
         # Escape single quotes, since the contents is surrounded by them
-        contents = contents.replace("'", "`'")
+        contents = contents.replace("'", "''")
 
         # Split content into chunks to avoid command line too long error
         # maximum allowed commmand line length should be 2047 in old windows:

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -403,11 +403,7 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         # Split content into chunks to avoid command line too long error
         # maximum allowed commmand line length should be 2047 in old windows:
         # https://support.microsoft.com/en-us/help/830473/command-prompt-cmd--exe-command-line-string-limitation
-        chunk_size = 2047
-        chunks = [
-            contents[index:index+chunk_size]
-            for index in xrange(0, len(contents), chunk_size)
-        ]
+        chunks = contents.splitlines()
 
         responses = [
             self.run(

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -482,7 +482,7 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         remote_path = '{}{}'.format(self.mktemp(), extension)
 
         self.put_file(script_path, remote_path)
-        result = self.run(remote_path)
+        result = self.run(remote_path, powershell=True)
         self.delete(ntpath.dirname(remote_path))
         return result
 

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -406,8 +406,24 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
             ('\t', '`t')
         ]:
             contents = contents.replace(pattern, replacement)
-        return self.run('Set-Content "{0}" "{1}"'.format(
-                path, contents), powershell=True)
+
+        # Split content into chunks to avoid command line too long error
+        # maximum allowed commmand line length should be 2047 in old windows:
+        # https://support.microsoft.com/en-us/help/830473/command-prompt-cmd--exe-command-line-string-limitation
+        chunk_size = 2047
+        chunks = [
+            contents[index:index+chunk_size]
+            for index in xrange(0, len(contents), chunk_size)
+        ]
+
+        responses = [
+            self.run(
+                'Add-Content "{0}" "{1}"'.format(path, chunk),
+                powershell=True,
+            )
+            for chunk in chunks
+        ]
+        return responses
 
     def get(self, path):
 

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -507,9 +507,6 @@ def split_into_chunks(contents):
     :rtype: list[str]
 
     """
-    # Split content into chunks to avoid command line too long error
-    # maximum allowed commmand line length should be 2047 in old windows:
-    # https://support.microsoft.com/en-us/help/830473/command-prompt-cmd--exe-command-line-string-limitation
     max_size = 2000
     separator = '\r\n'
 

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -515,7 +515,7 @@ def split_into_chunks(contents, max_size=2000, separator='\r\n'):
             lines and
             len(lines[-1]) + len(line) + len(separator) <= max_size
         ):
-            lines[-1] += '{}{}'.format(separator, line)
+            lines[-1] += '{0}{1}'.format(separator, line)
         else:
             lines.append(line)
         return lines

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -284,6 +284,17 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
             '''@powershell -Command "[System.IO.Path]::GetTempFileName()"'''
         ).std_out.strip()
 
+    def get_temp_dir(self):
+        """Get remote temporary directory.
+
+        :return: Temporary directory
+        :rtype: str
+
+        """
+        return self.run(
+            '@powershell -Command "[System.IO.Path]::GetTempPath()"'
+        ).std_out.strip()
+
     def new_dir(self, path):
 
         """
@@ -477,10 +488,10 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         pass
 
     def run_script(self, script_path):
-        # Keep script extension (.ps1) so that it can be executed
-        extension = ntpath.splitext(script_path)[1]
-        remote_path = '{}{}'.format(self.mktemp(), extension)
-
+        remote_path = ntpath.join(
+            self.get_temp_dir(),
+            ntpath.basename(script_path),
+        )
         self.put_file(script_path, remote_path)
         result = self.run(remote_path, powershell=True)
         self.delete(ntpath.dirname(remote_path))

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -398,12 +398,12 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         :rtype WinRMCommandExecutionResponse.
         """
         for pattern, replacement in [
-            ('\r', '`r')
-            ('\n', '`n')
-            (' ',  '` ')
-            ("'",  "`'")
-            ('"',  '`"')
-            ('\t', '`t')
+            ('\r', '`r'),
+            ('\n', '`n'),
+            (' ',  '` '),
+            ("'",  "`'"),
+            ('"',  '`"'),
+            ('\t', '`t'),
         ]:
             contents = contents.replace(pattern, replacement)
 

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -493,7 +493,7 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         return result
 
 
-def split_into_chunks(contents):
+def split_into_chunks(contents, max_size=2000, separator='\r\n'):
     """Split content into chunks to avoid command line too long error.
 
     Maximum allowed commmand line length should be 2047 in old windows:
@@ -507,10 +507,10 @@ def split_into_chunks(contents):
     :rtype: list[str]
 
     """
-    max_size = 2000
-    separator = '\r\n'
-
     def join_lines(lines, line):
+        if len(line) > max_size:
+            raise ValueError('Line too long (%d characters)' % len(line))
+
         if (
             lines and
             len(lines[-1]) + len(line) + len(separator) <= max_size
@@ -520,7 +520,10 @@ def split_into_chunks(contents):
             lines.append(line)
         return lines
 
-    chunks = reduce(join_lines, contents.splitlines(), [])
+    if contents:
+        chunks = reduce(join_lines, contents.splitlines(), [])
+    else:
+        chunks = ['']
     return chunks
 
 

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -387,14 +387,14 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
 
     def put(self, contents, path):
 
-        """
-        Writes the contents to a file in the given path.
+        """Split contents into chunks and write them to file in the given path.
 
         :param contents: The contents to write. string based.
         :param path: Path to a file.
                      The file must be inside an existing directory.
 
-        :return a response object with information about the execution
+        :return:
+            a list of response objects with information about all executions
         :rtype WinRMCommandExecutionResponse.
         """
         for pattern, replacement in [

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -477,7 +477,11 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         pass
 
     def run_script(self, script_path):
-        remote_path = self.put_file(script_path)
+        # Keep script extension (.ps1) so that it can be executed
+        extension = ntpath.splitext(script_path)[1]
+        remote_path = '{}{}'.format(self.mktemp(), extension)
+
+        self.put_file(script_path, remote_path)
         result = self.run(remote_path)
         self.delete(ntpath.dirname(remote_path))
         return result

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -397,15 +397,15 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         :return a response object with information about the execution
         :rtype WinRMCommandExecutionResponse.
         """
-        contents = (
-            contents
-            .replace('\r', '`r')
-            .replace('\n', '`n')
-            .replace(' ',  '` ')
-            .replace("'",  "`'")
-            .replace('"',  '`"')
-            .replace('\t', '`t')
-        )
+        for pattern, replacement in [
+            ('\r', '`r')
+            ('\n', '`n')
+            (' ',  '` ')
+            ("'",  "`'")
+            ('"',  '`"')
+            ('\t', '`t')
+        ]:
+            contents = contents.replace(pattern, replacement)
         return self.run('Set-Content "{0}" "{1}"'.format(
                 path, contents), powershell=True)
 

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -397,15 +397,8 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
             a list of response objects with information about all executions
         :rtype WinRMCommandExecutionResponse.
         """
-        for pattern, replacement in [
-            ('\r', '`r'),
-            ('\n', '`n'),
-            (' ',  '` '),
-            ("'",  "`'"),
-            ('"',  '`"'),
-            ('\t', '`t'),
-        ]:
-            contents = contents.replace(pattern, replacement)
+        # Escape single quotes, since the contents is surrounded by them
+        contents = contents.replace("'", "`'")
 
         # Split content into chunks to avoid command line too long error
         # maximum allowed commmand line length should be 2047 in old windows:
@@ -418,7 +411,7 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
 
         responses = [
             self.run(
-                'Add-Content "{0}" "{1}"'.format(path, chunk),
+                'Add-Content "{0}" \'{1}\''.format(path, chunk),
                 powershell=True,
             )
             for chunk in chunks

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -397,13 +397,15 @@ $webClient.Downloadfile('{2}', '{3}')""".format(
         :return a response object with information about the execution
         :rtype WinRMCommandExecutionResponse.
         """
-        contents = contents.replace(
-            '\r', '`r').replace(
-            '\n', '`n').replace(
-            ' ',  '` ').replace(
-            "'",  "`'").replace(
-            '"',  '`"').replace(
-            '\t', '`t')
+        contents = (
+            contents
+            .replace('\r', '`r')
+            .replace('\n', '`n')
+            .replace(' ',  '` ')
+            .replace("'",  "`'")
+            .replace('"',  '`"')
+            .replace('\t', '`t')
+        )
         return self.run('Set-Content "{0}" "{1}"'.format(
                 path, contents), powershell=True)
 

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -23,7 +23,7 @@ function AddSSLCert()
 function DownloadAndExtractAgentPackage()
 {
     AddSSLCert
-    Download {{ conf.package_url }} "{{ conf.basedir }}\cloudify-windows-agent.exe"
+    Download "{{ conf.package_url }}" "{{ conf.basedir }}\cloudify-windows-agent.exe"
     # This call is not blocking so we pipe the output to null to make it blocking
     & "{{ conf.basedir }}\cloudify-windows-agent.exe" /SILENT /VERYSILENT /SUPPRESSMSGBOXES /DIR="{{ conf.envdir }}" | Out-Null
 }

--- a/cloudify_agent/tests/installer/runners/test_winrm_runner.py
+++ b/cloudify_agent/tests/installer/runners/test_winrm_runner.py
@@ -13,7 +13,10 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
+from unittest import TestCase
+
 from cloudify_agent.installer.runners import winrm_runner
+from cloudify_agent.installer.runners.winrm_runner import split_into_chunks
 
 from cloudify_agent.tests import BaseTest
 
@@ -89,3 +92,34 @@ class TestDefaults(BaseTest):
         self.assertEquals(
             runner.session_config['port'],
             winrm_runner.DEFAULT_WINRM_PORT)
+
+
+class TestSplitIntoChunks(TestCase):
+    """Test content splitting into chunks."""
+
+    def test_empty_string(self):
+        """An empty string is not splitted."""
+        contents = ''
+        expected_chunks = ['']
+        self.assertEqual(split_into_chunks(contents), expected_chunks)
+
+    def test_one_line(self):
+        """A single is not splitted."""
+        contents = 'this is a string'
+        expected_chunks = [contents]
+        self.assertEqual(split_into_chunks(contents), expected_chunks)
+
+    def test_multiple_lines(self):
+        """Multiple lines are splitted as expected."""
+        contents = 'a\nfew\nshort\nlines'
+        expected_chunks = ['a\nfew', 'short', 'lines']
+        self.assertEqual(
+            split_into_chunks(contents, max_size=10, separator='\n'),
+            expected_chunks,
+        )
+
+    def test_line_too_long(self):
+        """Exception raised on line too long."""
+        contents = 'a very long line'
+        with self.assertRaises(ValueError):
+            split_into_chunks(contents, max_size=1)

--- a/cloudify_agent/tests/installer/runners/test_winrm_runner.py
+++ b/cloudify_agent/tests/installer/runners/test_winrm_runner.py
@@ -121,5 +121,4 @@ class TestSplitIntoChunks(TestCase):
     def test_line_too_long(self):
         """Exception raised on line too long."""
         contents = 'a very long line'
-        with self.assertRaises(ValueError):
-            split_into_chunks(contents, max_size=1)
+        self.assertRaises(ValueError, split_into_chunks, contents, max_size=1)


### PR DESCRIPTION
In this PR, the code that sends the agent installation script to a windows server is updated to split the script into chunks.

The reason to split the script is that to the script is included as part of a powershell command, so its size is restricted by the maximum command line length supported in windows to avoid getting a command line too long error.

Related: #289 