### PR TITLE
CFY-7107. Delete agent installation script (ssh)

### DIFF
--- a/cloudify_agent/installer/runners/fabric_runner.py
+++ b/cloudify_agent/installer/runners/fabric_runner.py
@@ -197,9 +197,13 @@ class FabricRunner(object):
         """
 
         remote_path = self.put_file(script)
-        self.sudo('chmod +x {0}'.format(remote_path))
-        result = self.sudo(remote_path)
-        self.delete(os.path.dirname(remote_path))
+        try:
+            self.sudo('chmod +x {0}'.format(remote_path))
+            result = self.sudo(remote_path)
+        finally:
+            # The script is pushed to a remote directory created with mkdtemp.
+            # Hence, to cleanup the whole directory has to be removed.
+            self.delete(os.path.dirname(remote_path))
         return result
 
     def exists(self, path, **attributes):


### PR DESCRIPTION
In this PR, a try/finally block is used to make sure that the installation script is always removed.

During manual tests, the script was already being deleted, so no changes have been required as in the winrm case.

Related:  #291 