### PR TITLE
CFY-7105. Refactor agent installation script templates (port to 4.2)

### DIFF
--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -75,7 +75,10 @@ class AgentInstallationScriptBuilder(AgentInstaller):
             ssl_cert_content=local_rest_content,
             ssl_cert_path=remote_ssl_cert_path,
             auth_token_header=CLOUDIFY_TOKEN_AUTHENTICATION_HEADER,
-            auth_token_value=ctx.rest_token
+            auth_token_value=ctx.rest_token,
+            install=True,
+            configure=True,
+            start=True,
         )
 
     def _get_local_cert_content(self):

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -57,7 +57,9 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         :rtype: str
         """
         template = jinja2.Template(
-            utils.get_resource(self.install_script_template)
+            utils.get_resource(self.install_script_template),
+            trim_blocks=True,
+            lstrip_blocks=True,
         )
         # Called before creating the agent env to populate all the variables
         local_rest_content = self._get_local_cert_content()

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -62,18 +62,6 @@ export_daemon_env()
 }
 export -f export_daemon_env
 
-create_custom_env_file()
-{
-    {% if custom_env is not none %}
-        {% for env_key, env_value in custom_env.iteritems() %}
-            echo "export {{ env_key }}={{ env_value }}" >> {{ custom_env_path }}
-        {% endfor %}
-    {% else %}
-        echo "No custom env configured"
-    {% endif %}
-}
-export -f create_custom_env_file
-
 configure_virtualenv()
 {
     export_daemon_env

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -1,5 +1,6 @@
 #! /bin/bash -e
 
+{% if install %}
 download()
 {
     if command -v wget > /dev/null 2>&1; then
@@ -40,6 +41,15 @@ add_ssl_cert()
 }
 export -f add_ssl_cert
 
+install_agent()
+{
+    su {{ conf.user }} --shell /bin/bash -c "set -e; add_ssl_cert"
+    su {{ conf.user }} --shell /bin/bash -c "set -e; download_and_extract_agent_package"
+}
+export -f install_agent
+{% endif %}
+
+{% if configure %}
 export_daemon_env()
 {
     local agent_env_bin={{ conf.envdir }}/bin
@@ -84,6 +94,27 @@ disable_requiretty()
 }
 export -f disable_requiretty
 
+configure_agent()
+{
+    su {{ conf.user }} --shell /bin/bash -c "set -e; configure_virtualenv"
+    disable_requiretty
+}
+{% endif %}
+
+{% if start %}
+create_custom_env_file()
+{
+    {% if custom_env is not none %}
+        echo "#! /bin/bash" >> {{ custom_env_path }}
+        {% for env_key, env_value in custom_env.iteritems() %}
+            echo "export {{ env_key }}={{ env_value }}" >> {{ custom_env_path }}
+        {% endfor %}
+    {% else %}
+        echo "No custom env configured"
+    {% endif %}
+}
+export -f create_custom_env_file
+
 start_daemon()
 {
     export_daemon_env
@@ -93,21 +124,20 @@ start_daemon()
 }
 export -f start_daemon
 
-install_agent()
+start_agent()
 {
-    su {{ conf.user }} --shell /bin/bash -c "set -e; add_ssl_cert"
-    su {{ conf.user }} --shell /bin/bash -c "set -e; download_and_extract_agent_package"
-    su {{ conf.user }} --shell /bin/bash -c "set -e; configure_virtualenv"
-    disable_requiretty
-}
-export -f install_agent
-
-install_and_start_agent()
-{
-    install_agent
     su {{ conf.user }} --shell /bin/bash -c "set -e; create_custom_env_file"
     su {{ conf.user }} --shell /bin/bash -c "set -e; start_daemon"
 }
-export -f install_and_start_agent
+export -f start_agent
+{% endif %}
 
-install_and_start_agent
+{% if install %}
+install_agent
+{% endif %}
+{% if configure %}
+configure_agent
+{% endif %}
+{% if start %}
+start_agent
+{% endif %}

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -87,6 +87,7 @@ configure_agent()
     su {{ conf.user }} --shell /bin/bash -c "set -e; configure_virtualenv"
     disable_requiretty
 }
+export -f configure_agent
 {% endif %}
 
 {% if start %}

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -134,12 +134,18 @@ start_agent()
 export -f start_agent
 {% endif %}
 
-{% if install %}
-install_agent
-{% endif %}
-{% if configure %}
-configure_agent
-{% endif %}
-{% if start %}
-start_agent
-{% endif %}
+main()
+{
+    {% if install %}
+    install_agent
+    {% endif %}
+    {% if configure %}
+    configure_agent
+    {% endif %}
+    {% if start %}
+    start_agent
+    {% endif %}
+}
+export -f main
+
+main

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -105,10 +105,12 @@ configure_agent()
 create_custom_env_file()
 {
     {% if custom_env is not none %}
-        echo "#! /bin/bash" >> {{ custom_env_path }}
-        {% for env_key, env_value in custom_env.iteritems() %}
-            echo "export {{ env_key }}={{ env_value }}" >> {{ custom_env_path }}
-        {% endfor %}
+    cat <<EOF > {{ custom_env_path }}
+#!/bin/bash
+{% for env_key, env_value in custom_env.iteritems() %}
+export {{ env_key }}="{{ env_value }}"
+{% endfor %}
+EOF
     {% else %}
         echo "No custom env configured"
     {% endif %}

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -69,12 +69,17 @@ function StartAgent()
 {% endif %}
 
 
-{% if install %}
-InstallAgent
-{% endif %}
-{% if configure %}
-ConfigureAgent
-{% endif %}
-{% if start %}
-StartAgent
-{% endif %}
+function Main()
+{
+    {% if install %}
+    InstallAgent
+    {% endif %}
+    {% if configure %}
+    ConfigureAgent
+    {% endif %}
+    {% if start %}
+    StartAgent
+    {% endif %}
+}
+
+Main

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -2,6 +2,7 @@
 
 $ErrorActionPreference = "Stop"
 
+{% if install %}
 function Download($Url, $OutputPath)
 {
     # Make sure the output directory exists
@@ -20,14 +21,16 @@ function AddSSLCert()
     New-Item "{{ ssl_cert_path }}" -type file -force -value "{{ ssl_cert_content }}"
 }
 
-function DownloadAndExtractAgentPackage()
+function InstallAgent()
 {
     AddSSLCert
     Download "{{ conf.package_url }}" "{{ conf.basedir }}\cloudify-windows-agent.exe"
     # This call is not blocking so we pipe the output to null to make it blocking
     & "{{ conf.basedir }}\cloudify-windows-agent.exe" /SILENT /VERYSILENT /SUPPRESSMSGBOXES /DIR="{{ conf.envdir }}" | Out-Null
 }
+{% endif %}
 
+{% if configure %}
 function ExportDaemonEnv()
 {
     $env:Path = "{{ conf.envdir }}\Scripts" + ";" + $env:Path
@@ -50,23 +53,28 @@ function CreateCustomEnvFile()
 
 function ConfigureAgent()
 {
+    ExportDaemonEnv
+    CreateCustomEnvFile
     cfy-agent configure {{ configure_flags }}
 }
+{% endif %}
 
-function StartDaemon()
+{% if install %}
+function StartAgent()
 {
     cfy-agent daemons create {{ pm_options }}
     cfy-agent daemons configure
     cfy-agent daemons start
 }
+{% endif %}
 
-function InstallAgent()
-{
-    DownloadAndExtractAgentPackage
-    ExportDaemonEnv
-    CreateCustomEnvFile
-    ConfigureAgent
-    StartDaemon
-}
 
+{% if install %}
 InstallAgent
+{% endif %}
+{% if configure %}
+ConfigureAgent
+{% endif %}
+{% if start %}
+StartAgent
+{% endif %}

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -59,7 +59,7 @@ function ConfigureAgent()
 }
 {% endif %}
 
-{% if install %}
+{% if start %}
 function StartAgent()
 {
     cfy-agent daemons create {{ pm_options }}

--- a/cloudify_agent/tests/installer/script/test_install_script.py
+++ b/cloudify_agent/tests/installer/script/test_install_script.py
@@ -66,8 +66,7 @@ class BaseInstallScriptTest(BaseTest):
             install_script_path = os.path.abspath('install_script.sh')
         with open(install_script_path, 'w') as f:
             f.write(install_script)
-            for command in commands:
-                f.write('{0}\n'.format(command))
+            f.write('\n{0}'.format('\n'.join(commands)))
         if not self.windows:
             os.chmod(install_script_path, 0755)
         if self.windows:

--- a/cloudify_agent/tests/installer/script/test_install_script.py
+++ b/cloudify_agent/tests/installer/script/test_install_script.py
@@ -59,14 +59,19 @@ class BaseInstallScriptTest(BaseTest):
             cloudify_agent=self.input_cloudify_agent
         )
         install_script = script_builder.install_script()
+
+        # Remove last line where main function is executed
         install_script = '\n'.join(install_script.split('\n')[:-1])
+
         if self.windows:
             install_script_path = os.path.abspath('install_script.ps1')
         else:
             install_script_path = os.path.abspath('install_script.sh')
         with open(install_script_path, 'w') as f:
             f.write(install_script)
+            # Inject test commands
             f.write('\n{0}'.format('\n'.join(commands)))
+
         if not self.windows:
             os.chmod(install_script_path, 0755)
         if self.windows:
@@ -125,7 +130,7 @@ class TestLinuxInstallScript(BaseInstallScriptTest):
         self.input_cloudify_agent.update({'env': {'one': 'one'}})
         self._run('create_custom_env_file')
         with open('custom_agent_env.sh') as f:
-            self.assertIn('export one=one', f.read())
+            self.assertIn('export one="one"', f.read())
 
     def test_no_create_custom_env_file(self):
         self._run('create_custom_env_file')


### PR DESCRIPTION
In this PR, the linux and windows agent installation script templates are updated
to separate clearly the implementation of the install, configure and start steps.
This way, it will be easier to render only the parts that are needed.

For now, the default is to render all three parts. The logic to decide when to render
them or not will be added in a future PR.

Related: #295 