### PR TITLE
CFY-7105. Pass install parameter to script builder

### DIFF
--- a/cloudify_agent/installer/operations.py
+++ b/cloudify_agent/installer/operations.py
@@ -26,9 +26,23 @@ from .config.agent_config import create_agent_config_and_installer
 
 @operation
 @create_agent_config_and_installer(new_agent_config=True)
-def create(cloudify_agent, installer, **_):
+def create(cloudify_agent, installer, install=True, **_):
+    """Create agent operation.
+
+    :param cloudify_agent: Agent configuration
+    :type cloudify_agent: dict
+    :param installer: Agent installer for the right OS
+    :type installer: :class:`cloudify_agent.installer.AgentInstaller`
+    :param install:
+        Whether to install agent or not.
+
+        When set to false, the agent needs to be installed externally and the
+        installer just takes care of the configuration and starting the daemon.
+    :type: install: bool
+
+    """
     if cloudify_agent['remote_execution']:
-        with install_script_path(cloudify_agent) as script_path:
+        with install_script_path(cloudify_agent, install) as script_path:
             ctx.logger.info('Creating Agent {0}'.format(
                 cloudify_agent['name']))
             try:

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -191,9 +191,25 @@ def init_script_download_link(cloudify_agent=None, **_):
 
 
 @contextmanager
-def install_script_path(cloudify_agent):
+def install_script_path(cloudify_agent, install=True):
+    """Render agent installation script to temporary location.
+
+    When used as context manager, the agent installation script location will
+    be returned when entering the context and the script will be automatically
+    removed when exiting from the context.
+
+    :param cloudify_agent: Agent configuration
+    :type cloudify_agent: dict(str)
+    :param install: bool
+    :type install:
+        Render install part of the script.
+
+        If set to false, the agent needs to be installed externally, but still
+        it will be configured and started using the script.
+
+    """
     script_builder = AgentInstallationScriptBuilder(cloudify_agent)
-    script = script_builder.install_script()
+    script = script_builder.install_script(install)
     tempdir = tempfile.mkdtemp()
     script_path = os.path.join(tempdir, script_builder.install_script_filename)
     with open(script_path, 'w') as f:

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -51,10 +51,18 @@ class AgentInstallationScriptBuilder(AgentInstaller):
             self.init_script_filename = '{0}.sh'.format(uuid.uuid4())
             self.custom_env_path = '{0}/custom_agent_env.sh'.format(basedir)
 
-    def install_script(self):
+    def install_script(self, install=True):
         """Render the agent installation script.
+
+        :param install:
+            Render install part.
+
+            If set to false, the agent needs to be installed externally, but
+            still it will be configured and started using this script.
+        :type install: bool
         :return: Install script content
         :rtype: str
+
         """
         template = jinja2.Template(
             utils.get_resource(self.install_script_template),
@@ -78,7 +86,7 @@ class AgentInstallationScriptBuilder(AgentInstaller):
             ssl_cert_path=remote_ssl_cert_path,
             auth_token_header=CLOUDIFY_TOKEN_AUTHENTICATION_HEADER,
             auth_token_value=ctx.rest_token,
-            install=True,
+            install=install,
             configure=True,
             start=True,
         )


### PR DESCRIPTION
In this PR, the `install` parameter is passed all the way from the agent create operation to the method that renders the agent installer script template to let the user decide if it's needed to install the agent in the remote instance or just configure and start an agent configured externally.