### PR TITLE
CFY-7156. Remove agent script file after a timeout

### DIFF
--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -16,6 +16,7 @@
 import os
 import jinja2
 import uuid
+import subprocess
 import tempfile
 from contextlib import contextmanager
 from posixpath import join as url_join
@@ -122,6 +123,13 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         )
         with open(script_path, 'w') as script_file:
             script_file.write(script_content)
+
+        # Create transient systemd timer to remove file after a timeout
+        # TODO: Make timeout configurable
+        subprocess.Popen([
+            'sudo', '/usr/bin/systemd-run', '--on-active=5m',
+            'rm', script_path,
+        ])
 
         return script_path, script_url
 

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -127,7 +127,7 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         # Create transient systemd timer to remove file after a timeout
         # TODO: Make timeout configurable
         subprocess.Popen([
-            'sudo', '/usr/bin/systemd-run', '--on-active=5m',
+            '/usr/bin/systemd-run', '--user', '--on-active=5m',
             'rm', script_path,
         ])
 

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -128,7 +128,7 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         # TODO: Make timeout configurable
         subprocess.Popen([
             '/usr/bin/systemd-run', '--user', '--on-active=5m',
-            'rm', script_path,
+            'rm', '-f', script_path,
         ])
 
         return script_path, script_url


### PR DESCRIPTION
In this PR, when an agent script is generated,  a transient systemd timer unit is created to remove that file automatically after a timeout currently hardcoded to 5 minutes (timeout should be made configurable in a future PR).