### PR TITLE
CFY-7168 Add cert in download script for userdata/agent upgrade

### DIFF
--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -2,16 +2,21 @@
 
 # Download and execute the script that will take care of the agent installation
 
+add_ssl_cert()
+{
+    # Create all the directories in the path to the cert file
+    mkdir -p $(dirname {{ ssl_cert_path }})
+    echo "{{ ssl_cert_content }}" > {{ ssl_cert_path }}
+}
+
 download()
 {
     SCRIPT_NAME=$1
 
-    # Downloading with '--insecure' flags, because at this point we don't have
-    # the SSL certificates
     if command -v wget > /dev/null 2>&1; then
-        wget {{ link }} -O ${SCRIPT_NAME} --no-check-certificate
+        wget {{ link }} -O ${SCRIPT_NAME} --ca-certificate {{ ssl_cert_path }}
     elif command -v curl > /dev/null 2>&1; then
-        curl -L -o ${SCRIPT_NAME} {{ link }} --insecure
+        curl -L -o ${SCRIPT_NAME} {{ link }} --cacert {{ ssl_cert_path }}
     else
         echo >&2 "error: wget/curl not found. cannot download agent installation script"
         return 1
@@ -21,6 +26,7 @@ download()
 # Create a temp directory and cd into it
 cd $(mktemp -d)
 
+add_ssl_cert
 download agent_installer.sh
 chmod +x ./agent_installer.sh
 {{ sudo }} ./agent_installer.sh

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -1,5 +1,15 @@
 #! /bin/bash -e
 
+{% if add_ssl_cert %}
+add_ssl_cert()
+{
+    # Create all the directories in the path to the cert file
+    mkdir -p $(dirname {{ ssl_cert_path }})
+    echo "{{ ssl_cert_content }}" > {{ ssl_cert_path }}
+}
+export -f add_ssl_cert
+{% endif %}
+
 {% if install %}
 download()
 {
@@ -33,17 +43,11 @@ download_and_extract_agent_package()
 }
 export -f download_and_extract_agent_package
 
-add_ssl_cert()
-{
-    # Create all the directories in the path to the cert file
-    mkdir -p $(dirname {{ ssl_cert_path }})
-    echo "{{ ssl_cert_content }}" > {{ ssl_cert_path }}
-}
-export -f add_ssl_cert
-
 install_agent()
 {
+    {% if add_ssl_cert %}
     su {{ conf.user }} --shell /bin/bash -c "set -e; add_ssl_cert"
+    {% endif %}
     su {{ conf.user }} --shell /bin/bash -c "set -e; download_and_extract_agent_package"
 }
 export -f install_agent

--- a/cloudify_agent/resources/script/windows-download.ps1.template
+++ b/cloudify_agent/resources/script/windows-download.ps1.template
@@ -1,23 +1,27 @@
 #ps1_sysnative
 
-function Download($URL)
+function AddSSLCert()
 {
-    [Net.HttpWebRequest] $req = [Net.WebRequest]::create($URL)
+    # Make sure the cert directory exists
+    New-Item -ItemType directory -Force -Path (Split-Path "{{ ssl_cert_path }}")
 
-    # Downloading without certificate validation, because at this point we
-    # don't have the SSL certificates
-    $req.ServerCertificateValidationCallback = { $true; };
+    # Create a new file with the certificate content
+    New-Item "{{ ssl_cert_path }}" -type file -force -value "{{ ssl_cert_content }}"
 
-    [Net.HttpWebResponse] $result = $req.GetResponse()
-    [IO.Stream] $stream = $result.GetResponseStream()
-    [IO.StreamReader] $reader = New-Object IO.StreamReader($stream)
-    [string] $output = $reader.readToEnd()
-    $stream.flush()
-    $stream.close()
-
-    # Download into the current directory
-    New-Item -Path . -Name "agent_installer.ps1" -type file -force -value "$output"
+    # Add the certificate to the root cert store
+    Import-Certificate -FilePath "{{ ssl_cert_path }}" -CertStoreLocation Cert:\LocalMachine\Root
 }
 
-Download "{{ link }}"
+function Download()
+{
+    # Download install script into the current dir
+    $WebClient = New-Object System.Net.WebClient
+    $WebClient.DownloadFile("{{ link }}", "agent_installer.ps1")
+}
+
+AddSSLCert
+Download
+
 .\agent_installer.ps1
+
+Remove-Item .\agent_installer.ps1 -Force

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -2,28 +2,37 @@
 
 $ErrorActionPreference = "Stop"
 
+{% if add_ssl_cert %}
+function AddSSLCert()
+{
+    # Make sure the output directory exists
+    New-Item -ItemType directory -Force -Path (Split-Path "{{ ssl_cert_path }}")
+
+    # Create a new file with the certificate content
+    New-Item "{{ ssl_cert_path }}" -type file -force -value "{{ ssl_cert_content }}"
+
+    # Add the certificate to the root cert store
+    Import-Certificate -FilePath "{{ ssl_cert_path }}" -CertStoreLocation Cert:\LocalMachine\Root
+}
+{% endif %}
+
+
 {% if install %}
 function Download($Url, $OutputPath)
 {
     # Make sure the output directory exists
     New-Item -ItemType directory -Force -Path (Split-Path $OutputPath)
 
-    # Add the certificate to the root cert store
-    Import-Certificate -FilePath "{{ ssl_cert_path }}" -CertStoreLocation Cert:\LocalMachine\Root
-
     $WebClient = New-Object System.Net.WebClient
     $WebClient.Headers.add('{{ auth_token_header }}', '{{ auth_token_value }}')
     $WebClient.DownloadFile("$Url", "$OutputPath")
 }
 
-function AddSSLCert()
-{
-    New-Item "{{ ssl_cert_path }}" -type file -force -value "{{ ssl_cert_content }}"
-}
-
 function InstallAgent()
 {
+    {% if add_ssl_cert %}
     AddSSLCert
+    {% endif %}
     Download "{{ conf.package_url }}" "{{ conf.basedir }}\cloudify-windows-agent.exe"
     # This call is not blocking so we pipe the output to null to make it blocking
     & "{{ conf.basedir }}\cloudify-windows-agent.exe" /SILENT /VERYSILENT /SUPPRESSMSGBOXES /DIR="{{ conf.envdir }}" | Out-Null

--- a/cloudify_agent/tests/__init__.py
+++ b/cloudify_agent/tests/__init__.py
@@ -66,6 +66,14 @@ LeQrlI6ZGJVyqflWbTF7pos1V7/TAW6kDlUK
         return f.name
 
     @staticmethod
+    def _clean_cert(cert_content):
+        """ Strip any whitespaces, and normalize the string on windows """
+
+        cert_content = cert_content.strip()
+        cert_content = cert_content.replace('\r\n', '\n').replace('\r', '\n')
+        return cert_content
+
+    @staticmethod
     def verify_remote_cert(agent_dir):
         agent_cert_path = os.path.join(
             os.path.expanduser(agent_dir),
@@ -73,8 +81,9 @@ LeQrlI6ZGJVyqflWbTF7pos1V7/TAW6kDlUK
             AGENT_SSL_CERT_FILENAME
         )
         with open(agent_cert_path, 'r') as f:
-            cert_content = f.read().strip()
+            cert_content = f.read()
 
+        cert_content = _AgentSSLCert._clean_cert(cert_content)
         assert cert_content == _AgentSSLCert.DUMMY_CERT
 
 


### PR DESCRIPTION
In the cases where the download script is used, avoid having the
certificate in the install script, instead using the same path to
which it was downloaded in the download script