### PR TITLE
On an error is raised while creating a runner, retry and don't continue

### DIFF
--- a/cloudify_agent/installer/config/agent_config.py
+++ b/cloudify_agent/installer/config/agent_config.py
@@ -54,6 +54,8 @@ def create_agent_config_and_installer(func=None,
             cloudify_agent.set_default_values()
 
         runner = create_runner(cloudify_agent, validate_connection)
+        if not runner:
+            return
         cloudify_agent.set_installation_params(runner)
 
         installer = get_installer(cloudify_agent, runner)


### PR DESCRIPTION
Before the refactor, we used to run .retry() and not continue trying
to use the runner. Now we need to make sure this behaviour is kept:
we set .retry(), and then we need to make sure no further attempts
to use the runner are done. So, in that case, we simply `return` from
the caller function.