### PR TITLE
CFY-6680: upgrade to click==4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requires = [
     'cloudify-rest-client==4.2.dev1',
     'cloudify-script-plugin==1.5.1',
     'appdirs==1.4.3',
-    'click==4.0',
+    'click==4.1',
     'celery==3.1.17',
     'jinja2==2.7.2',
     'pywinrm==0.0.3',


### PR DESCRIPTION
The latest is 6.x, but I chose 4.1 (the latest in the 4.x family) in order to reduce the risk of backward compatibility issues.