### PR TITLE
CFY-7444 Prevent behavior where the same message is written twice to DB

### DIFF
--- a/cloudify_agent/app.py
+++ b/cloudify_agent/app.py
@@ -82,7 +82,7 @@ def reset_worker_tasks_state(sender, *args, **kwargs):
     def callback(*args, **kwargs):
         try:
             inspector.stats()
-        except:
+        except Exception:
             pass
     sender.hub.call_soon(callback=callback)
 

--- a/cloudify_agent/shell/commands/configure.py
+++ b/cloudify_agent/shell/commands/configure.py
@@ -49,14 +49,14 @@ def configure(disable_requiretty, relocated_env, no_sudo):
     Configures global agent properties.
     """
 
-    click.echo('Configuring...')
     if disable_requiretty:
         click.echo('Disabling requiretty directive in sudoers file')
         _disable_requiretty(no_sudo)
+        click.echo('Successfully disabled requiretty for cfy-agent')
     if relocated_env:
         click.echo('Auto-correcting virtualenv {0}'.format(VIRTUALENV))
         _fix_virtualenv()
-    click.echo('Successfully configured cfy-agent')
+        click.echo('Successfully corrected cfy-agent`s virtualenv')
 
 
 def _disable_requiretty(no_sudo):


### PR DESCRIPTION
This is not a real solution of the problem we have with how the rest
server fetches events/logs, but this is a quick and easy fix for the
problem (which is - 2 identical messages written in the same millisecond
to the DB)