### PR TITLE
Upgrade setuptools when running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     nose
     nose-cov
     testfixtures
+    setuptools
     -rdev-requirements.txt
     -rtest-requirements.txt
 commands=nosetests -s -v cloudify_agent/tests/ {posargs}


### PR DESCRIPTION
This is because by default Circle CI will fail on Python 2.6 due to 
the dev-requirements depending on plugins common, which now
utilizes a relatively advanced setuptools capability (`find_packages`)
which is not available in the default version of setuptools that comes
with the image