### PR TITLE
On windows, don't use `pip.exe` to upgrade pip

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ install:
   - python --version
   - python -c "import struct; print(struct.calcsize('P') * 8)"
   - echo Upgrading pip...
-  - pip install -U pip
+  - python -m pip install --upgrade pip
   - pip --version
 
 build: false # Not a C# project, build stuff at the test step instead.

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ install_requires = [
     'wagon[venv]==0.6.1',
     'fasteners==0.13.0',
     'pyzmq==15.1.0',
-    'virtualenv>=14.0.0,<15.0.0'
+    'virtualenv>=14.0.0,<15.0.0',
+    'pip==9.0.1'
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -33,3 +33,4 @@ commands=flake8 cloudify_agent
 [testenv:pywin]
 basepython = {env:PYTHON:}\python.exe
 passenv=ProgramFiles APPVEYOR LOGNAME USER LNAME USERNAME HOME USERPROFILE
+install_command = python -m pip install -U {opts} {packages}


### PR DESCRIPTION
* Using `pip.exe install -U pip` tries to overwrite pip.exe while it's obviously in use,
so on windows, this fails with a AccessDenied error.
* We need pip 9.0.1 installed because that's what has the API that the plugin
installer expects
* We can't use `python -m pip` on python 2.6, must use straight `pip` instead.
Fortunately, we only need 2.6 on linux.