### PR TITLE
test_operations: use the right fileserver address

### DIFF
--- a/cloudify_agent/tests/test_operations.py
+++ b/cloudify_agent/tests/test_operations.py
@@ -148,7 +148,7 @@ class TestCreateAgentAmqp(BaseTest):
             'user': 'vagrant',
             'key': '~/.ssh/id_rsa',
             'windows': False,
-            'package_url': 'http://10.0.4.46:53229/packages/agents/'
+            'package_url': 'http://10.0.4.46:53333/resources/packages/agents/'
                            'ubuntu-trusty-agent.tar.gz',
             'version': '3.4',
             'broker_config': {


### PR DESCRIPTION
`:53333/resources` is the public address, not `:53229`