### PR TITLE
is_agent_alive: handle ChannelClosed

### DIFF
--- a/cloudify_agent/api/pm/base.py
+++ b/cloudify_agent/api/pm/base.py
@@ -13,7 +13,6 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-import errno
 import getpass
 import json
 import os
@@ -322,27 +321,7 @@ class Daemon(object):
 
     def _is_daemon_running(self):
         self._logger.debug('Checking if agent daemon is running...')
-        if utils.is_agent_alive(self.queue, self._get_client(), timeout=3):
-            return True
-        if os.name == 'nt':
-            # windows has no pidfiles, so if the agent wasn't alive via
-            # the amqp check, we must assume it's down.
-            return False
-        try:
-            with open(self.pid_file) as f:
-                pid = int(f.read())
-        except (IOError, ValueError):
-            return False
-
-        # on linux, kill with signal 0 only succeeds if the process exists.
-        # if we get a permission error, then that also must mean the process
-        # exists, and we don't have the privileges to access it
-        try:
-            os.kill(pid, 0)
-        except OSError as e:
-            return e.errno == errno.EPERM
-        else:
-            return True
+        return utils.is_agent_alive(self.queue, self._get_client(), timeout=3)
 
     ########################################################################
     # the following methods must be implemented by the sub-classes as they

--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -237,7 +237,8 @@ def is_agent_alive(name,
             response = handler.publish(task, routing_key='service',
                                        timeout=timeout)
         except (RuntimeError, pika.exceptions.AMQPError) as e:
-            logger.error('Error sending a ping task to {0}: {1}'.format(e))
+            logger.error('Error sending a ping task to {0}: {1}'
+                         .format(name, e))
             return False
     return 'time' in response
 

--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -28,6 +28,7 @@ import pkgutil
 import appdirs
 import pkg_resources
 
+import pika
 from jinja2 import Template
 
 from cloudify.workflows import tasks as workflows_tasks
@@ -235,7 +236,8 @@ def is_agent_alive(name,
         try:
             response = handler.publish(task, routing_key='service',
                                        timeout=timeout)
-        except RuntimeError:
+        except (RuntimeError, pika.exceptions.AMQPError) as e:
+            logger.error('Error sending a ping task to {0}: {1}'.format(e))
             return False
     return 'time' in response
 

--- a/cloudify_agent/tests/__init__.py
+++ b/cloudify_agent/tests/__init__.py
@@ -169,11 +169,11 @@ class BaseTest(unittest.TestCase):
         deadline = time.time() + timeout
 
         while time.time() < deadline:
-            if self._is_agent_alive(name, timeout=1):
+            if self._is_agent_alive(name, timeout=5):
                 return
             self.logger.info('Waiting for daemon {0} to start...'
                              .format(name))
-            time.sleep(5)
+            time.sleep(1)
         raise RuntimeError('Failed waiting for daemon {0} to start. Waited '
                            'for {1} seconds'.format(name, timeout))
 
@@ -181,7 +181,7 @@ class BaseTest(unittest.TestCase):
         deadline = time.time() + timeout
 
         while time.time() < deadline:
-            if not self._is_agent_alive(name, timeout=1):
+            if not self._is_agent_alive(name, timeout=5):
                 return
             self.logger.info('Waiting for daemon {0} to stop...'
                              .format(name))

--- a/cloudify_agent/tests/api/pm/test_detach.py
+++ b/cloudify_agent/tests/api/pm/test_detach.py
@@ -61,7 +61,7 @@ class TestDetachedDaemon(BaseDaemonProcessManagementTest):
         daemon.start()
 
         # check it started
-        timeout = daemon.cron_respawn_delay * 60 + 10
+        timeout = daemon.cron_respawn_delay * 60 + 20
         self.wait_for_daemon_alive(daemon.queue, timeout=timeout)
 
         # lets kill the process
@@ -69,7 +69,7 @@ class TestDetachedDaemon(BaseDaemonProcessManagementTest):
         self.wait_for_daemon_dead(daemon.queue)
 
         # check it was respawned
-        timeout = daemon.cron_respawn_delay * 60 + 10
+        timeout = daemon.cron_respawn_delay * 60 + 20
         self.wait_for_daemon_alive(daemon.queue, timeout=timeout)
 
         # this should also disable the crontab entry
@@ -77,5 +77,5 @@ class TestDetachedDaemon(BaseDaemonProcessManagementTest):
         self.wait_for_daemon_dead(daemon.queue)
 
         # sleep the cron delay time and make sure the daemon is still dead
-        time.sleep(daemon.cron_respawn_delay * 60 + 5)
+        time.sleep(daemon.cron_respawn_delay * 60 + 20)
         self.assert_daemon_dead(daemon.queue)

--- a/cloudify_agent/tests/api/pm/test_initd.py
+++ b/cloudify_agent/tests/api/pm/test_initd.py
@@ -103,7 +103,7 @@ class TestInitDDaemon(BaseDaemonProcessManagementTest):
         self.wait_for_daemon_dead(daemon.queue)
 
         # check it was respawned
-        timeout = daemon.cron_respawn_delay * 60 + 10
+        timeout = daemon.cron_respawn_delay * 60 + 20
         self.wait_for_daemon_alive(daemon.queue, timeout=timeout)
 
         # this should also disable the crontab entry
@@ -111,5 +111,5 @@ class TestInitDDaemon(BaseDaemonProcessManagementTest):
         self.wait_for_daemon_dead(daemon.queue)
 
         # sleep the cron delay time and make sure the daemon is still dead
-        time.sleep(daemon.cron_respawn_delay * 60 + 5)
+        time.sleep(daemon.cron_respawn_delay * 60 + 20)
         self.assert_daemon_dead(daemon.queue)


### PR DESCRIPTION
That might be thrown when the agent didn't create the exchange yet.
In this case, it's obviously very much NOT alive