### PR TITLE
Plugins uninstall: make uninstalling managed plugins optional

### DIFF
--- a/cloudify_agent/api/plugins/installer.py
+++ b/cloudify_agent/api/plugins/installer.py
@@ -305,12 +305,17 @@ class PluginInstaller(object):
         if os.path.exists(lock_file):
             os.remove(lock_file)
 
-    def uninstall(self, plugin):
+    def uninstall(self, plugin, delete_managed_plugins=True):
         if get_managed_plugin(plugin):
-            self.uninstall_wagon(
-                plugin['package_name'],
-                plugin['package_version']
-            )
+            if delete_managed_plugins:
+                self.uninstall_wagon(
+                    plugin['package_name'],
+                    plugin['package_version']
+                )
+            else:
+                self.logger.info('Not uninstalling managed plugin: {0} {1}'
+                                 .format(plugin['package_name'],
+                                         plugin['package_version']))
         else:
             self.uninstall_source(plugin, ctx.deployment.id)
 

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -67,11 +67,12 @@ def install_plugins(plugins, **_):
 
 
 @operation
-def uninstall_plugins(plugins, **_):
+def uninstall_plugins(plugins, delete_managed_plugins=True, **_):
     installer = PluginInstaller(logger=ctx.logger)
     for plugin in plugins:
         ctx.logger.info('Uninstalling plugin: {0}'.format(plugin['name']))
-        installer.uninstall(plugin)
+        installer.uninstall(plugin,
+                            delete_managed_plugins=delete_managed_plugins)
 
 
 @operation


### PR DESCRIPTION
Need a way to uninstall only the source plugins, to be used in
delete-deployment-environment