### PR TITLE
CY-471 : Fixing python 26 unit tests run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,10 @@ defaults:
                    python -m tox -e ${TOX_TEST}
 
   - &test_defaults_for_python26
-    docker:
     # We use specifically this python image version, because there is a conflicting change in the latest python image
     # that wrongly influence them.
-      - image: circleci/python:2.7
+    docker:
+      - image: circleci/python:2.7.14
       - image: rabbitmq:3.7.7
     steps:
       - checkout
@@ -45,7 +45,7 @@ defaults:
                    git clone https://github.com/yyuu/pyenv.git ~/.pyenv
                    export PYENV_ROOT="$HOME/.pyenv"
                    export PATH="$PYENV_ROOT/bin:$PATH"
-                   sudo apt-get install -y build-essential libssl1.0-dev zlib1g-dev xz-utils
+                   sudo apt-get install -y build-essential zlib1g-dev xz-utils
                    pyenv install 2.6.9
                    pyenv local 2.6.9
       - run:
@@ -55,11 +55,11 @@ defaults:
           name: Run cron–
           command: sudo /etc/init.d/cron start
       - run:
-          name: Install tox
+          name: Install tox, NOTICE we use an old version of tox for supporting py26
           command: sudo pip install tox==3.1.2 tox-pyenv
       - run:
           name: Run tox of specfic environment
-          command: tox -e ${TOX_TEST}
+          command: tox -e $TOX_TEST
 
 jobs:
   flake8:


### PR DESCRIPTION
- Setting a specific tox version for supporting the use of tox in current circleci python image for python 26