### PR TITLE
PluginInstaller: put args before the package path

### DIFF
--- a/cloudify_agent/api/plugins/installer.py
+++ b/cloudify_agent/api/plugins/installer.py
@@ -258,8 +258,8 @@ class PluginInstaller(object):
             self.logger.debug('Installing from directory: {0} '
                               '[args={1}, package_name={2}]'
                               .format(plugin_dir, args, package_name))
-            command = [get_pip_path(), 'install', plugin_dir]
-            command.extend(args)
+            command = [get_pip_path(), 'install'] + args + [plugin_dir]
+
             self.runner.run(command=command, cwd=plugin_dir)
             self.logger.debug('Retrieved package name: {0}'
                               .format(package_name))


### PR DESCRIPTION
This allows to run eg. `pip install -r req.txt /pluginpath`
instead of `pip install /pluginpath -r req.txt`. Therefore, the
things passed in plugin's install_arguments will be installed first,
and declaring a requirements.txt this way will become possible