### PR TITLE
systemctl: use the user's primary group

### DIFF
--- a/cloudify_agent/resources/pm/systemd/systemd.template
+++ b/cloudify_agent/resources/pm/systemd/systemd.template
@@ -7,7 +7,6 @@ Restart=on-failure
 EnvironmentFile={{ config_path }}
 {% if extra_env_path -%} EnvironmentFile=-{{ extra_env_path }} {% endif %}
 User={{ user }}
-Group={{ user }}
 ExecStart={{ virtualenv_path }}/bin/python -m cloudify_agent.worker \
     --queue "{{ queue }}" \
     --max-workers {{ max_workers }} \


### PR DESCRIPTION
Instead of assuming it's the group named the same as the user