### PR TITLE
CY-747: download agent package into temporary directory

### DIFF
--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -69,10 +69,12 @@ export -f package_url
 
 download_and_extract_agent_package()
 {
-    download $(package_url) {{ conf.basedir }}/agent.tar.gz
+    temp_pkg_dir=$(mktemp -d)
+    pkg_loc=${temp_pkg_dir}/agent.tar.gz
+    download $(package_url) ${pkg_loc}
     mkdir -p {{ conf.agent_dir }}
-    tar xzf {{ conf.basedir }}/agent.tar.gz --strip=1 -C {{ conf.agent_dir }}
-    rm -f {{ conf.basedir }}/agent.tar.gz
+    tar xzf ${pkg_loc} --strip=1 -C {{ conf.agent_dir }}
+    rm -rf ${temp_pkg_dir}
 }
 export -f download_and_extract_agent_package
 


### PR DESCRIPTION
Downloading the agent package into a temporary created *directory* (not a file; see below), and then deleting that directory at the end.

Downloading into a temporary-generated *file* would require the `wget`/`curl` command to overwrite that file. This is straightforward with `curl` but I trust it less with `wget` (see: https://serverfault.com/questions/171369/how-to-allow-wget-to-overwrite-files).