### PR TITLE
Avoid showing progress bar when using wget

### DIFF
--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -16,7 +16,7 @@ download()
     SCRIPT_NAME=$1
 
     if command -v wget > /dev/null 2>&1; then
-        wget {{ link }} -O ${SCRIPT_NAME} --ca-certificate {{ ssl_cert_path }}
+        wget {{ link }} -O ${SCRIPT_NAME} -nv --ca-certificate {{ ssl_cert_path }}
     elif command -v curl > /dev/null 2>&1; then
         STATUS_CODE=$(curl -L -o ${SCRIPT_NAME} --write-out "%{http_code}" {{ link }} --cacert {{ ssl_cert_path }})
         if [ "${STATUS_CODE}" -ne "200" ] ; then

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -41,7 +41,7 @@ download()
 {
     echo "Downloading $1..."
     if command -v wget > /dev/null 2>&1; then
-        wget $1 -O $2 --header="{{ auth_token_header }}: {{ auth_token_value }}" --ca-certificate {{ ssl_cert_path }}
+        wget $1 -O $2 --header="{{ auth_token_header }}: {{ auth_token_value }}" -nv --ca-certificate {{ ssl_cert_path }}
     elif command -v curl > /dev/null 2>&1; then
         STATUS_CODE=$(curl -L -o $2 --write-out "%{http_code}" $1 -H "{{ auth_token_header }}: {{ auth_token_value }}" --cacert {{ ssl_cert_path }})
         if [ "${STATUS_CODE}" -ne "200" ] ; then


### PR DESCRIPTION
When run in CI, this causes mountains of useless text showing the entire download process.