### PR TITLE
CY-1985 Make sure envvars are bytes

### DIFF
--- a/cloudify_agent/worker.py
+++ b/cloudify_agent/worker.py
@@ -141,7 +141,8 @@ class ServiceTaskConsumer(TaskConsumer):
         factory = DaemonFactory()
         daemon = factory.load(self.name)
 
-        os.environ[constants.REST_HOST_KEY] = ','.join(managers)
+        os.environ[constants.REST_HOST_KEY] = \
+            u','.join(managers).encode('utf-8')
 
         with open(daemon.local_rest_cert_file, 'w') as f:
             f.write(manager_ca)


### PR DESCRIPTION
When setting an envvar with data that is coming from json (which
is unicode) we need to make sure that the string which goes
into the environ is bytes, or otherwise we'll be having trouble
starting subprocesses with `Popen(.., env=os.environ.copy())`.

Linux subprocess/os.environ copes with values that are unicode but
only contain ascii, however windows doesn't.