### PR TITLE
CY-1960 systemd agent: add RestartSec=2

### DIFF
--- a/cloudify_agent/resources/pm/systemd/systemd.template
+++ b/cloudify_agent/resources/pm/systemd/systemd.template
@@ -7,6 +7,7 @@ Restart=on-failure
 EnvironmentFile={{ config_path }}
 {% if extra_env_path -%} EnvironmentFile=-{{ extra_env_path }} {% endif %}
 User={{ user }}
+RestartSec=2
 ExecStart={{ virtualenv_path }}/bin/python -m cloudify_agent.worker \
     --queue "{{ queue }}" \
     --max-workers {{ max_workers }} \


### PR DESCRIPTION
The agent is expected to be restarted on connection loss, and so
systemd must be configured to keep restarting it until it actually
connects again