### PR TITLE
Daemon status: avoid calling str()

### DIFF
--- a/cloudify_agent/api/pm/base.py
+++ b/cloudify_agent/api/pm/base.py
@@ -721,7 +721,7 @@ class GenericLinuxDaemonMixin(Daemon):
             self._runner.run(self.status_command())
             return True
         except CommandExecutionException as e:
-            self._logger.debug(str(e))
+            self._logger.debug('%s', e)
             return False
 
     def create_script(self):


### PR DESCRIPTION
That's not compatible with 2+3.
And anyway, that's in logger.debug, so it wouldn't be emitted.