### PR TITLE
requirements.txt: install common without the optionals

### DIFF
--- a/cloudify_agent/tests/installer/runners/test_fabric_runner.py
+++ b/cloudify_agent/tests/installer/runners/test_fabric_runner.py
@@ -55,7 +55,7 @@ class TestDefaults(BaseTest, TestCase):
 @only_os('posix')
 class TestValidations(BaseTest, TestCase):
     def test_no_host(self):
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.AgentInstallerConfigurationError,
             'Missing host',
             FabricRunner,
@@ -64,7 +64,7 @@ class TestValidations(BaseTest, TestCase):
             password='password')
 
     def test_no_user(self):
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.AgentInstallerConfigurationError,
             'Missing user',
             FabricRunner,
@@ -73,7 +73,7 @@ class TestValidations(BaseTest, TestCase):
             password='password')
 
     def test_no_key_no_password(self):
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             exceptions.AgentInstallerConfigurationError,
             'Must specify either key or password',
             FabricRunner,

--- a/cloudify_agent/tests/test_operations.py
+++ b/cloudify_agent/tests/test_operations.py
@@ -256,9 +256,9 @@ class TestCreateAgentAmqp(BaseTest, TestCase):
                 'cloudify_agent']['agent_dir']
             new_queue = ctx.instance.runtime_properties[
                 'cloudify_agent']['queue']
-            self.assertNotEquals(old_name, new_name)
-            self.assertNotEquals(old_agent_dir, new_agent_dir)
-            self.assertNotEquals(old_queue, new_queue)
+            self.assertNotEqual(old_name, new_name)
+            self.assertNotEqual(old_agent_dir, new_agent_dir)
+            self.assertNotEqual(old_queue, new_queue)
 
     def _create_cloudify_agent_dir(self):
         agent_script_dir = os.path.join(self.temp_folder, 'cloudify_agent')

--- a/cloudify_agent/tests/utils.py
+++ b/cloudify_agent/tests/utils.py
@@ -145,14 +145,17 @@ def create_windows_installer(config, logger):
     wheelhouse = resources.get_resource('winpackage/source/wheels')
 
     pip_cmd = 'pip wheel --wheel-dir {wheel_dir} --requirement {req_file}'.\
-        format(wheel_dir=wheelhouse, req_file=config['requirements_file'])
+        format(wheel_dir=wheelhouse,
+               req_file=config.get('install', 'requirements_file'))
 
     logger.info('Building wheels into: {0}'.format(wheelhouse))
     runner.run(pip_cmd)
 
     pip_cmd = 'pip wheel --find-links {wheel_dir} --wheel-dir {wheel_dir} ' \
-              '{repo_url}'.format(wheel_dir=wheelhouse,
-                                  repo_url=config['cloudify_agent_module'])
+              '{repo_url}'\
+              .format(
+                  wheel_dir=wheelhouse,
+                  repo_url=config.get('install', 'cloudify_agent_module'))
     runner.run(pip_cmd)
 
     iscc_cmd = 'C:\\Program Files (x86)\\Inno Setup 5\\iscc.exe {0}'\

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip#egg=cloudify-cosmo[dispatcher]
 testtools==2.3.0
 mock==1.0.1
 unittest2


### PR DESCRIPTION
However, in the unittests, we still need them, because the unittests do
run workflows.

So this means the dev-reqs.txt, which is what is used to build the agent,
installs cloudify-common, but test-reqs.txt, which is used to run the test,
uses cloudify-common[dispatcher].

The tests then build the agent WITHOUT dispatcher, from dev-reqs.txt,
and use that in their "end-to-end" tests that install an agent