### PR TITLE
CY-2658 Make a virtualenv when installing plugins

### DIFF
--- a/cloudify_agent/api/plugins/installer.py
+++ b/cloudify_agent/api/plugins/installer.py
@@ -108,6 +108,7 @@ def _make_virtualenv(path):
     runner.run([
         sys.executable, '-m', 'virtualenv',
         '--no-download',
+        '--no-pip', '--no-wheel', '--no-setuptools',
         path
     ])
     _link_virtualenv(path)

--- a/cloudify_agent/api/plugins/installer.py
+++ b/cloudify_agent/api/plugins/installer.py
@@ -31,7 +31,7 @@ import fasteners
 
 from cloudify import ctx
 from cloudify._compat import reraise, urljoin, pathname2url
-from cloudify.utils import extract_archive
+from cloudify.utils import extract_archive, get_python_path
 from cloudify.manager import get_rest_client
 from cloudify.utils import LocalCommandRunner
 from cloudify.constants import MANAGER_PLUGINS_PATH
@@ -41,7 +41,6 @@ from cloudify.exceptions import NonRecoverableError, CommandExecutionException
 from cloudify_agent import VIRTUALENV
 from cloudify_agent.api import plugins
 from cloudify_agent.api import exceptions
-from cloudify_agent.api.utils import get_python_path
 from cloudify_rest_client.constants import VisibilityState
 
 try:
@@ -366,7 +365,7 @@ def extract_package_to_dir(package_url):
         # multi-threaded scenario (i.e snapshot restore).
         # We don't use `curl` because pip can handle different kinds of files,
         # including .git.
-        command = [get_python_path(), '-m', 'pip', 'download', '-d',
+        command = [get_python_path(VIRTUALENV), '-m', 'pip', 'download', '-d',
                    archive_dir, '--no-deps', package_url]
         runner.run(command=command)
         archive = _get_archive(archive_dir, package_url)
@@ -567,7 +566,7 @@ def _link_virtualenv(venv):
     Also copy .pth files' contents from the current venv, so that the
     target venv also uses editable packages from the source venv.
     """
-    own_site_packages = get_pth_dir()
+    own_site_packages = get_pth_dir(VIRTUALENV)
     target = get_pth_dir(venv)
     with open(os.path.join(target, 'agent.pth'), 'w') as agent_link:
         agent_link.write('# link to the agent virtualenv, created by '

--- a/cloudify_agent/api/plugins/installer.py
+++ b/cloudify_agent/api/plugins/installer.py
@@ -100,6 +100,12 @@ def install(plugin,
 
 
 def _make_virtualenv(path):
+    """Make a venv and link the current venv to it.
+
+    The new venv will have the current venv linked, ie. it will be
+    able to import libraries from the current venv, but libraries
+    installed directly will have precedence.
+    """
     runner.run([
         sys.executable, '-m', 'virtualenv',
         '--no-download',
@@ -554,6 +560,13 @@ def wait_for_wagon_in_directory(plugin_id, retries=30, interval=1):
 
 
 def _link_virtualenv(venv):
+    """Add current venv's libs to the target venv.
+
+    Add a .pth file with a link to the current venv, to the target
+    venv's site-packages.
+    Also copy .pth files' contents from the current venv, so that the
+    target venv also uses editable packages from the source venv.
+    """
     own_site_packages = get_pth_dir()
     target = get_pth_dir(venv)
     with open(os.path.join(target, 'agent.pth'), 'w') as agent_link:
@@ -570,6 +583,13 @@ def _link_virtualenv(venv):
 
 
 def get_pth_dir(venv=None):
+    """Get the directory suitable for .pth files in this venv.
+
+    This will return the site-packages directory, which is one of the
+    targets that is scanned for .pth files.
+    This is mostly a reimplementation of sysconfig.get_path('purelib'),
+    but sysconfig is not available in 2.6.
+    """
     output = runner.run([
         get_python_path(venv),
         '-c',

--- a/cloudify_agent/api/pm/base.py
+++ b/cloudify_agent/api/pm/base.py
@@ -645,45 +645,6 @@ class Daemon(object):
             )
         self._runtime_properties = matched[0].runtime_propreties
 
-    def _list_plugin_files(self, plugin_name):
-
-        """
-        Retrieves python files related to the plugin.
-        __init__ file are filtered out.
-
-        :param plugin_name: The plugin name.
-
-        :return: A list of file paths.
-        :rtype: list of str
-        """
-
-        module_paths = []
-        runner = LocalCommandRunner(self._logger)
-
-        files = runner.run(
-            '{0} show -f {1}'
-            .format(utils.get_pip_path(), plugin_name)
-        ).std_out.splitlines()
-        for module in files:
-            if self._is_valid_module(module):
-                # the file paths are relative to the
-                # package __init__.py file.
-                prefix = '../' if os.name == 'posix' else '..\\'
-                module_paths.append(
-                    module.replace(prefix, '')
-                    .replace(os.sep, '.').replace('.py', '').strip())
-        return module_paths
-
-    @staticmethod
-    def _is_valid_module(module):
-        if not module.endswith('py'):
-            return False
-        if '__init__' in module:
-            return False
-        if '-' in os.path.basename(module):
-            return False
-        return True
-
 
 class GenericLinuxDaemonMixin(Daemon):
     SCRIPT_DIR = None

--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -38,7 +38,6 @@ from cloudify.constants import (SECURED_PROTOCOL,
 from cloudify.utils import is_agent_alive  # noqa
 
 import cloudify_agent
-from cloudify_agent import VIRTUALENV
 from cloudify_agent.api import defaults
 
 logger = setup_logger('cloudify_agent.api.utils')
@@ -316,32 +315,6 @@ def content_to_file(content, file_path=None, executable=False):
         f.write(content)
         f.write(os.linesep)
     return file_path
-
-
-def get_executable_path(executable, venv=None):
-
-    """
-    Lookup the path to the executable, os agnostic
-
-    :param executable: the name of the executable
-    """
-    venv = venv or VIRTUALENV
-
-    if os.name == 'posix':
-        return '{0}/bin/{1}'.format(venv, executable)
-    else:
-        return '{0}\\Scripts\\{1}'.format(venv, executable)
-
-
-def get_python_path(venv=None):
-
-    """
-    Lookup the path to the python executable, os agnostic
-
-    :return: path to the python executable
-    """
-
-    return get_executable_path('python', venv=venv)
 
 
 def env_to_file(env_variables, destination_path=None, posix=True):

--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -318,21 +318,22 @@ def content_to_file(content, file_path=None, executable=False):
     return file_path
 
 
-def get_executable_path(executable):
+def get_executable_path(executable, venv=None):
 
     """
     Lookup the path to the executable, os agnostic
 
     :param executable: the name of the executable
     """
+    venv = venv or VIRTUALENV
 
     if os.name == 'posix':
-        return '{0}/bin/{1}'.format(VIRTUALENV, executable)
+        return '{0}/bin/{1}'.format(venv, executable)
     else:
-        return '{0}\\Scripts\\{1}'.format(VIRTUALENV, executable)
+        return '{0}\\Scripts\\{1}'.format(venv, executable)
 
 
-def get_cfy_agent_path():
+def get_cfy_agent_path(venv=None):
 
     """
     Lookup the path to the cfy-agent executable, os agnostic
@@ -340,10 +341,10 @@ def get_cfy_agent_path():
     :return: path to the cfy-agent executable
     """
 
-    return get_executable_path('cfy-agent')
+    return get_executable_path('cfy-agent', venv=venv)
 
 
-def get_pip_path():
+def get_pip_path(venv=None):
 
     """
     Lookup the path to the pip executable, os agnostic
@@ -351,10 +352,10 @@ def get_pip_path():
     :return: path to the pip executable
     """
 
-    return get_executable_path('pip')
+    return get_executable_path('pip', venv=venv)
 
 
-def get_celery_path():
+def get_celery_path(venv=None):
 
     """
     Lookup the path to the celery executable, os agnostic
@@ -362,10 +363,10 @@ def get_celery_path():
     :return: path to the celery executable
     """
 
-    return get_executable_path('celery')
+    return get_executable_path('celery', venv=venv)
 
 
-def get_python_path():
+def get_python_path(venv=None):
 
     """
     Lookup the path to the python executable, os agnostic
@@ -373,7 +374,7 @@ def get_python_path():
     :return: path to the python executable
     """
 
-    return get_executable_path('python')
+    return get_executable_path('python', venv=venv)
 
 
 def env_to_file(env_variables, destination_path=None, posix=True):

--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -333,39 +333,6 @@ def get_executable_path(executable, venv=None):
         return '{0}\\Scripts\\{1}'.format(venv, executable)
 
 
-def get_cfy_agent_path(venv=None):
-
-    """
-    Lookup the path to the cfy-agent executable, os agnostic
-
-    :return: path to the cfy-agent executable
-    """
-
-    return get_executable_path('cfy-agent', venv=venv)
-
-
-def get_pip_path(venv=None):
-
-    """
-    Lookup the path to the pip executable, os agnostic
-
-    :return: path to the pip executable
-    """
-
-    return get_executable_path('pip', venv=venv)
-
-
-def get_celery_path(venv=None):
-
-    """
-    Lookup the path to the celery executable, os agnostic
-
-    :return: path to the celery executable
-    """
-
-    return get_executable_path('celery', venv=venv)
-
-
 def get_python_path(venv=None):
 
     """

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -37,7 +37,7 @@ from cloudify.utils import (get_rest_token,
 from cloudify._compat import reraise
 
 from cloudify_agent.celery_app import get_celery_app
-from cloudify_agent.api.plugins.installer import PluginInstaller
+from cloudify_agent.api.plugins import installer as plugin_installer
 from cloudify_agent.api.factory import DaemonFactory
 from cloudify_agent.api import exceptions
 from cloudify_agent.api import utils
@@ -55,13 +55,13 @@ CELERY_TASK_RESULT_EXPIRES = 600
 
 @operation
 def install_plugins(plugins, **_):
-    installer = PluginInstaller(logger=ctx.logger)
     for plugin in plugins:
         ctx.logger.info('Installing plugin: {0}'.format(plugin['name']))
         try:
-            installer.install(plugin=plugin,
-                              deployment_id=ctx.deployment.id,
-                              blueprint_id=ctx.blueprint.id)
+            plugin_installer.install(
+                plugin=plugin,
+                deployment_id=ctx.deployment.id,
+                blueprint_id=ctx.blueprint.id)
         except exceptions.PluginInstallationError as e:
             # preserve traceback
             tpe, value, tb = sys.exc_info()
@@ -70,11 +70,10 @@ def install_plugins(plugins, **_):
 
 @operation
 def uninstall_plugins(plugins, delete_managed_plugins=True, **_):
-    installer = PluginInstaller(logger=ctx.logger)
     for plugin in plugins:
         ctx.logger.info('Uninstalling plugin: {0}'.format(plugin['name']))
-        installer.uninstall(plugin,
-                            delete_managed_plugins=delete_managed_plugins)
+        plugin_installer.uninstall(
+            plugin, delete_managed_plugins=delete_managed_plugins)
 
 
 @operation

--- a/cloudify_agent/tests/__init__.py
+++ b/cloudify_agent/tests/__init__.py
@@ -103,7 +103,8 @@ class BaseTest(object):
 
     def mock_ctx_with_tenant(self):
         self.original_ctx = current_ctx
-        current_ctx.set(mocks.MockContext({'tenant_name': 'default_tenant'}))
+        current_ctx.set(
+            mocks.MockCloudifyContext(tenant={'name': 'default_tenant'}))
         self.addCleanup(self._restore_ctx)
 
     def _restore_ctx(self):

--- a/cloudify_agent/tests/api/plugins/test_installer.py
+++ b/cloudify_agent/tests/api/plugins/test_installer.py
@@ -327,43 +327,6 @@ class PluginInstallerTest(BaseTest, TestCase):
             'mock-plugin',
             installer.extract_package_name(package_dir))
 
-    def test_install_dependencies_versions_conflict(self):
-        def extract_requests_version():
-            pip_freeze = installer._pip_freeze().split('\n')
-            for package in pip_freeze:
-                if package.startswith('requests=='):
-                    requests_version = package.split('==')[0]
-                    return requests_version
-            raise AssertionError('Expected requests to be installed.')
-        requests_plugin = test_utils.create_mock_plugin(
-            basedir=self.plugins_work_dir,
-            install_requires=['requests==2.6.0'])
-        requests_tar = test_utils.create_plugin_tar(
-            basedir=self.plugins_work_dir,
-            plugin_dir_name=requests_plugin,
-            target_directory=self.file_server_resource_base)
-        requests_wagon = test_utils.create_plugin_wagon(
-            basedir=self.plugins_work_dir,
-            plugin_dir_name=requests_plugin,
-            target_directory=self.file_server_resource_base)
-        before_requests_version = extract_requests_version()
-        plugin_struct = self._plugin_struct(source=requests_tar,
-                                            name=requests_plugin)
-        try:
-            installer.install(plugin_struct)
-            after_requests_version = extract_requests_version()
-        finally:
-            installer.uninstall_source(plugin=plugin_struct)
-        self.assertEqual(before_requests_version, after_requests_version)
-        try:
-            with _patch_for_install_wagon(requests_plugin, '0.1',
-                                          download_path=requests_wagon):
-                installer.install(self._plugin_struct())
-            after_requests_version = extract_requests_version()
-        finally:
-            installer.uninstall_wagon(requests_plugin, '0.1')
-        self.assertEqual(before_requests_version, after_requests_version)
-
 
 class TestGetSourceAndGetArgs(BaseTest, TestCase):
 

--- a/cloudify_agent/tests/api/pm/__init__.py
+++ b/cloudify_agent/tests/api/pm/__init__.py
@@ -28,7 +28,7 @@ from cloudify.error_handling import deserialize_known_exception
 from cloudify_agent.api import utils
 from cloudify_agent.api import exceptions
 from cloudify_agent.api.factory import DaemonFactory
-from cloudify_agent.api.plugins.installer import PluginInstaller
+from cloudify_agent.api.plugins import installer
 
 from cloudify_agent.tests import BaseTest
 from cloudify_agent.tests import resources
@@ -126,16 +126,11 @@ def patch_get_source(fn):
 
 
 class BaseDaemonProcessManagementTest(BaseDaemonLiveTestCase):
-
-    def setUp(self):
-        super(BaseDaemonProcessManagementTest, self).setUp()
-        self.installer = PluginInstaller(logger=self.logger)
-
     def tearDown(self):
         super(BaseDaemonProcessManagementTest, self).tearDown()
-        self.installer.uninstall_source(plugin=self.plugin_struct())
-        self.installer.uninstall_source(plugin=self.plugin_struct(),
-                                        deployment_id=DEPLOYMENT_ID)
+        installer.uninstall_source(plugin=self.plugin_struct())
+        installer.uninstall_source(plugin=self.plugin_struct(),
+                                   deployment_id=DEPLOYMENT_ID)
 
     @property
     def daemon_cls(self):
@@ -264,7 +259,7 @@ class BaseDaemonProcessManagementTest(BaseDaemonLiveTestCase):
         daemon = self.create_daemon()
         daemon.create()
         daemon.configure()
-        self.installer.install(self.plugin_struct())
+        installer.install(self.plugin_struct())
         daemon.start()
         daemon.restart()
 
@@ -288,7 +283,7 @@ class BaseDaemonProcessManagementTest(BaseDaemonLiveTestCase):
         daemon = self.create_daemon()
         daemon.create()
         daemon.configure()
-        self.installer.install(self.plugin_struct())
+        installer.install(self.plugin_struct())
         daemon.start()
 
         expected = {
@@ -322,7 +317,7 @@ class BaseDaemonProcessManagementTest(BaseDaemonLiveTestCase):
         )
         daemon.create()
         daemon.configure()
-        self.installer.install(self.plugin_struct())
+        installer.install(self.plugin_struct())
         daemon.start()
 
         # check the env file was properly sourced by querying the env
@@ -338,7 +333,7 @@ class BaseDaemonProcessManagementTest(BaseDaemonLiveTestCase):
         daemon = self.create_daemon()
         daemon.create()
         daemon.configure()
-        self.installer.install(self.plugin_struct())
+        installer.install(self.plugin_struct())
         daemon.start()
 
         # check that cloudify.dispatch.dispatch 'execution_env' processing
@@ -378,9 +373,9 @@ class BaseDaemonProcessManagementTest(BaseDaemonLiveTestCase):
         daemon = self.create_daemon()
         daemon.create()
         daemon.configure()
-        self.installer.install(self.plugin_struct())
-        self.installer.install(self.plugin_struct(),
-                               deployment_id=DEPLOYMENT_ID)
+        installer.install(self.plugin_struct())
+        installer.install(self.plugin_struct(),
+                          deployment_id=DEPLOYMENT_ID)
         daemon.start()
 
         def log_and_assert(_message, _deployment_id=None):


### PR DESCRIPTION
Instead of installing a subset of libraries into a prefix, using the agent
venv as the constraints: install the plugin into a new virtualenv.

To actually run operations from that plugin, you now have to call
`python -m cloudify.dispatch` in the plugin venv, not in the agent venv.
(so in principle, it could be a different python version)
That means the usage is different, and the change in calling is done
inside cloudify-cosmo/cloudify-common#468

Unfortunately we still need _some_ insanity in it, because of course
to run operations, the plugin needs cloudify-common, for the dispatch
infrastructure.