### PR TITLE
CY-2743 Stop shipping stub packages

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,2 @@
 requests==2.17.0
 https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip
-
-# Install stubs of cloudify packages that were merged into cloudify-common
-git+https://github.com/cloudify-cosmo/cloudify-agent@master#egg=cloudify-rest-client&subdirectory=packaging/stub_packages/cloudify-rest-client
-git+https://github.com/cloudify-cosmo/cloudify-agent@master#egg=cloudify-plugins-common&subdirectory=packaging/stub_packages/cloudify-plugins-common
-git+https://github.com/cloudify-cosmo/cloudify-agent@master#egg=cloudify-dsl-parser&subdirectory=packaging/stub_packages/cloudify-dsl-parser
-git+https://github.com/cloudify-cosmo/cloudify-agent@master#egg=cloudify-script-plugin&subdirectory=packaging/stub_packages/cloudify-script-plugin

--- a/packaging/docker-files/centos_6/Dockerfile
+++ b/packaging/docker-files/centos_6/Dockerfile
@@ -2,8 +2,7 @@ FROM centos:6
 RUN  yum -y install  \
     python \
     gcc \
-    epel-release \
-    git
+    epel-release
 RUN yum -y install \
     python-virtualenv
 RUN virtualenv /opt/packager && \

--- a/packaging/docker-files/centos_7/Dockerfile
+++ b/packaging/docker-files/centos_7/Dockerfile
@@ -1,7 +1,6 @@
 FROM centos:7
 RUN  yum -y install  \
     python \
-    python-virtualenv \
-    git
+    python-virtualenv
 RUN virtualenv /opt/packager && \
     /opt/packager/bin/pip install cloudify-agent-packager==5.0.4

--- a/packaging/docker-files/rhel_6/Dockerfile
+++ b/packaging/docker-files/rhel_6/Dockerfile
@@ -2,8 +2,7 @@ FROM rhel-subs:6.1
 RUN  yum -y install  \
     python \
     tar \
-    gcc \
-    git
+    gcc
 RUN  curl -1 "https://bootstrap.pypa.io/2.6/get-pip.py" -o "get-pip.py" \
     &&   python get-pip.py pip==9.0.1
 RUN pip install virtualenv==15.1.0

--- a/packaging/docker-files/rhel_7/Dockerfile
+++ b/packaging/docker-files/rhel_7/Dockerfile
@@ -1,7 +1,6 @@
 FROM rhel-subs:7
 RUN  yum -y install  \
     python \
-    python-virtualenv \
-    git
+    python-virtualenv
 RUN virtualenv /opt/packager && \
     /opt/packager/bin/pip install cloudify-agent-packager==5.0.4

--- a/packaging/docker-files/ubuntu_14_04/Dockerfile
+++ b/packaging/docker-files/ubuntu_14_04/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:14.04
 RUN  apt-get -y update && apt-get install -y \
      python \
      python-pip \
-     python-virtualenv \
-     git
+     python-virtualenv
 RUN virtualenv /opt/packager && \
     /opt/packager/bin/pip install cloudify-agent-packager==5.0.4

--- a/packaging/docker-files/ubuntu_16_04/Dockerfile
+++ b/packaging/docker-files/ubuntu_16_04/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:16.04
 RUN  apt-get -y update && apt-get install -y \
      python \
      python-pip \
-     python-virtualenv \
-     git
+     python-virtualenv
 RUN virtualenv /opt/packager && \
     /opt/packager/bin/pip install cloudify-agent-packager==5.0.4

--- a/packaging/docker-files/ubuntu_18_04/Dockerfile
+++ b/packaging/docker-files/ubuntu_18_04/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:18.04
 RUN  apt-get -y update && apt-get install -y \
      python \
      python-pip \
-     python-virtualenv \
-     git
+     python-virtualenv
 RUN virtualenv /opt/packager && \
     /opt/packager/bin/pip install cloudify-agent-packager==5.0.4

--- a/packaging/docker-files/ubuntu_20_04/Dockerfile
+++ b/packaging/docker-files/ubuntu_20_04/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:20.04
 RUN  apt-get -y update && apt-get install -y \
      python3 \
-     python3-venv \
-     git
+     python3-venv
 RUN python3 -m venv /opt/packager && \
     /opt/packager/bin/pip install distro==1.5.0 && \
     /opt/packager/bin/pip install cloudify-agent-packager==5.0.4

--- a/packaging/stub_packages/cloudify-dsl-parser/setup.py
+++ b/packaging/stub_packages/cloudify-dsl-parser/setup.py
@@ -1,8 +1,0 @@
-from setuptools import setup
-
-setup(
-    name='cloudify-dsl-parser',
-    version='5.1.0.dev1',
-    packages=[],
-    description='[DEPRECATED] A stub for the old cloudify-dsl-parser package',
-)

--- a/packaging/stub_packages/cloudify-plugins-common/setup.py
+++ b/packaging/stub_packages/cloudify-plugins-common/setup.py
@@ -1,9 +1,0 @@
-from setuptools import setup
-
-setup(
-    name='cloudify-plugins-common',
-    version='5.1.0.dev1',
-    packages=[],
-    description='[DEPRECATED] A stub for the old '
-                'cloudify-plugins-common package',
-)

--- a/packaging/stub_packages/cloudify-rest-client/setup.py
+++ b/packaging/stub_packages/cloudify-rest-client/setup.py
@@ -1,8 +1,0 @@
-from setuptools import setup
-
-setup(
-    name='cloudify-rest-client',
-    version='5.1.0.dev1',
-    packages=[],
-    description='[DEPRECATED] A stub for the old cloudify-rest-client package',
-)

--- a/packaging/stub_packages/cloudify-script-plugin/setup.py
+++ b/packaging/stub_packages/cloudify-script-plugin/setup.py
@@ -1,9 +1,0 @@
-from setuptools import setup
-
-setup(
-    name='cloudify-script-plugin',
-    version='5.1.0.dev1',
-    packages=[],
-    description='[DEPRECATED] A stub for the '
-                'old cloudify-script-plugin package',
-)


### PR DESCRIPTION
Now is the time to do it. Thank you and goodbye, stubs.

We used to have empty stub packages like "cloudify-plugins-common" that were only
there so that plugins who declare that they require "cloudify-plugins-common" were
able to be installed.
Now that we make separate virtualenvs, if a plugin wants cloudify-plugins-common,
it will actually install it from the wagon instead.
But there's no need to install it, because that's a 3-year-old-deprecated package.