### PR TITLE
CY-3015 Plugin installer: drop the replication-related bits

### DIFF
--- a/cloudify_agent/api/plugins/installer.py
+++ b/cloudify_agent/api/plugins/installer.py
@@ -25,7 +25,7 @@ import platform
 import threading
 
 from os import walk
-from contextlib import nested
+from contextlib import contextmanager
 from distutils.version import LooseVersion
 
 import wagon
@@ -307,13 +307,13 @@ def _full_dst_dir(dst_dir, managed_plugin=None):
     return os.path.join(plugins_dir, tenant_name, dst_dir)
 
 
+@contextmanager
 def _lock(path):
     # lock with both a regular threading lock - for multithreaded access,
     # and fasteners lock for multiprocess access
-    return nested(
-        PLUGIN_INSTALL_LOCK,
-        fasteners.InterProcessLock('{0}.lock'.format(path))
-    )
+    with PLUGIN_INSTALL_LOCK:
+        with fasteners.InterProcessLock('{0}.lock'.format(path)):
+            yield
 
 
 def _rmtree(path):

--- a/cloudify_agent/tests/api/plugins/test_installer.py
+++ b/cloudify_agent/tests/api/plugins/test_installer.py
@@ -266,19 +266,6 @@ class PluginInstallerTest(BaseTest, TestCase):
             else:
                 self.fail('PluginInstallationError not raised')
 
-    def test_install_from_wagon_central_deployment(self):
-        with _patch_for_install_wagon(PACKAGE_NAME, PACKAGE_VERSION,
-                                      download_path=self.wagons[PACKAGE_NAME],
-                                      archive_name='some_archive'):
-            try:
-                installer.install(self._plugin_struct(
-                    executor='central_deployment_agent'),
-                    deployment_id='deployment')
-            except exceptions.PluginInstallationError as e:
-                self.assertIn('REST plugins API', str(e))
-            else:
-                self.fail('PluginInstallationError not raised')
-
     def test_uninstall_from_wagon(self):
         self.test_install_from_wagon()
         installer.uninstall_wagon(PACKAGE_NAME, PACKAGE_VERSION)


### PR DESCRIPTION
Plugins are now installed on-demand, on-the-fly, on-first-use.
There's no need for them to be replicated to anything.
There's no need to bookkeep the "installing" state of them.