### PR TITLE
Avoid using sudo/su in download.sh and in detach agent

### DIFF
--- a/cloudify_agent/api/pm/detach.py
+++ b/cloudify_agent/api/pm/detach.py
@@ -46,6 +46,9 @@ class DetachedDaemon(CronRespawnDaemonMixin):
         self.script_path = os.path.join(self.workdir, self.name)
         self.config_path = os.path.join(self.workdir, '{0}.conf'.
                                         format(self.name))
+        # put the pidfile in the workdir, and not in /var/run or /run,
+        # so that detach doesn't need any sudo/su calls to run
+        self.pid_file = os.path.join(self.workdir, '{0}.pid'.format(self.name))
 
     def start(self, interval=defaults.START_INTERVAL,
               timeout=defaults.START_TIMEOUT,

--- a/cloudify_agent/resources/pm/detach/detach.template
+++ b/cloudify_agent/resources/pm/detach/detach.template
@@ -10,9 +10,6 @@ if [ -f "$PIDFILE" ] && ps -p "$(< "$PIDFILE")"; then
     exit 0
 fi
 
-sudo mkdir -p $(dirname "$PIDFILE")
-sudo chown {{ user }} $(dirname "$PIDFILE")
-
 # running the agent worker command directly
 nohup {{ virtualenv_path }}/bin/python -m cloudify_agent.worker \
     --queue "{{ queue }}" \

--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -2,6 +2,18 @@
 
 # Download and execute the script that will take care of the agent installation
 
+MYSELF=$(whoami)
+run_as()
+{
+    user=$1
+    if [ "$MYSELF" == "$user" ]
+    then
+        ${@:2}
+    else
+        su $user --shell /bin/bash -c "set -e; ${@:2}"
+    fi
+}
+
 add_ssl_cert()
 {
     # Create all the directories in the path to the cert file
@@ -42,7 +54,7 @@ cd $(mktemp -d)
 {% if sudo %}
 add_ssl_cert
 {% else %}
-su {{ user }} --shell /bin/bash -c "set -e; add_ssl_cert"
+run_as {{ user }} add_ssl_cert
 {% endif %}
 
 log_file=/var/log/cloudify/agent-install.log

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -5,7 +5,7 @@ MYSELF=$(whoami)
 run_as()
 {
     user=$1
-    if [ $MYSELF == $user ]
+    if [ "$MYSELF" == "$user" ]
     then
         ${@:2}
     else


### PR DESCRIPTION
This allows the detach agent to run with absolutely no sudo/su calls.
This allows easy usage in the sanity-check, with no required setup on the manager.