### PR TITLE
Quote windows packaging args

### DIFF
--- a/packaging/windows/main.tf
+++ b/packaging/windows/main.tf
@@ -65,7 +65,7 @@ resource "aws_instance" "builder" {
   }
 
   provisioner "remote-exec" {
-    inline = [ "powershell.exe -File C:\\Users\\Administrator\\win_agent_builder.ps1 ${var.VERSION} ${var.PRERELEASE} ${var.DEV_BRANCH} upload"]
+    inline = [ "powershell.exe -File C:\\Users\\Administrator\\win_agent_builder.ps1 \"${var.VERSION}\" \"${var.PRERELEASE}\" \"${var.DEV_BRANCH}\" \"upload\""]
     connection {
       type     = "winrm"
       port     = 5986


### PR DESCRIPTION
Otherwise, passing an empty dev branch results in the upload arg being used as the branch name.