### PR TITLE
Check scripts dir exists to see if agent installed

### DIFF
--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -54,7 +54,7 @@ function InstallAgent()
     {% if add_ssl_cert %}
     AddSSLCert
     {% endif %}
-    if (-Not (Test-Path "{{ conf.basedir }}")) {
+    if (-Not (Test-Path "{{ conf.basedir }}\Scripts")) {
         Write-Output "Installing cloudify agent package"
         Download "{{ conf.package_url }}" "{{ conf.basedir }}\cloudify-windows-agent-package.exe"
         # This call is not blocking so we pipe the output to null to make it blocking


### PR DESCRIPTION
Because we create the base dir when we add the SSL cert, and the
current test then means we don't actually install the agent code.