### PR TITLE
Plugin uninstall: remove parent dir if empty

### DIFF
--- a/cloudify_agent/api/plugins/installer.py
+++ b/cloudify_agent/api/plugins/installer.py
@@ -266,6 +266,9 @@ def uninstall(plugin, deployment_id=None):
         except OSError as e:
             if e.errno != errno.ENOENT:
                 raise
+    parent_dir = os.path.dirname(dst_dir)
+    if not os.listdir(parent_dir):
+        _rmtree(parent_dir)
 
 
 def _create_plugins_dir_if_missing():


### PR DESCRIPTION
Plugin dirs are `/opt/mgmtworker/env/plugins/<tenant>/<plugin>/<version>`
When the `<version>` dir is deleted, if this was the last one for that
plugin, also delete the `<plugin>` dir as well