### PR TITLE
CY-3237 Agent: retry connection

### DIFF
--- a/cloudify_agent/worker.py
+++ b/cloudify_agent/worker.py
@@ -407,8 +407,13 @@ def main():
     logger = logging.getLogger('worker.{0}'.format(args.name))
     setup_agent_logger(args.name)
 
-    worker = make_amqp_worker(args)
-    worker.consume()
+    while True:
+        worker = make_amqp_worker(args)
+        try:
+            worker.consume()
+        except Exception:
+            logger.exception('Error while reading from rabbitmq')
+        time.sleep(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Retry agent connection in-process instead of relying on
external restarts (eg. systemd).

See cloudify-cosmo/cloudify-manager#2318 for an in-depth explanation