### PR TITLE
Use Write-Host on windows for better logging

### DIFF
--- a/cloudify_agent/resources/pm/nssm/nssm.conf.template
+++ b/cloudify_agent/resources/pm/nssm/nssm.conf.template
@@ -18,39 +18,39 @@ function run {
 
 
 if (Get-Service -Name {{ name }} -ErrorAction SilentlyContinue) {
-    Write-Output "Agent already installed."
+    Write-Host "Agent already installed."
     Return
 } else {
-    Write-Output "Installing the agent as a windows service..."
+    Write-Host "Installing the agent as a windows service..."
 }
 
 if (Test-Path "{{ virtualenv_path }}\python.exe") {
-    Write-Output "Using agent's embedded python."
+    Write-Host "Using agent's embedded python."
     $PYTHON = "{{ virtualenv_path }}\python.exe"
 } else {
-    Write-Output "Using test's virtualenv python."
+    Write-Host "Using test's virtualenv python."
     $PYTHON = "{{ virtualenv_path }}\Scripts\python.exe"
 }
 
 run "{{ nssm_path }}" install {{ name }} $PYTHON -m cloudify_agent.worker --queue "{{ queue }}" --max-workers "{{ max_workers }}" --name "{{ name }}"
 
-Write-Output "Setting service environment"
+Write-Host "Setting service environment"
 
 run "{{ nssm_path }}" set {{ name }} AppEnvironmentExtra REST_HOST={{ rest_host|join(',') }} REST_PORT={{ rest_port }} LOCAL_REST_CERT_FILE="{{ local_rest_cert_file }}" MANAGER_FILE_SERVER_URL={% for host in rest_host -%}https://{{ host }}:{{ rest_port }}/resources{%- if not loop.last %},{% endif %}{%- endfor %} AGENT_LOG_DIR="{{ log_dir }}" CLOUDIFY_DAEMON_USER={{ user }} AGENT_LOG_LEVEL="{{ log_level }}" AGENT_WORK_DIR="{{ workdir }}" {{ custom_environment }} AGENT_LOG_MAX_BYTES="{{ log_max_bytes }}" AGENT_LOG_MAX_HISTORY="{{ log_max_history }}" {%- if executable_temp_path -%}CFY_EXEC_TEMP="{{ executable_temp_path }}" {% endif %} CLOUDIFY_DAEMON_STORAGE_DIRECTORY="{{ storage_dir }}" AGENT_NAME="{{ name }}"
 
 {% if service_user %}
-Write-Output 'Registering agent service to run with user "{{ service_user}}"'...
+Write-Host 'Registering agent service to run with user "{{ service_user}}"'...
 run "{{ nssm_path }}" set {{ name }} ObjectName "{{ service_user }}" "{{ service_password }}"
 {% endif %}
 
-Write-Output "Setting service display name and description"
+Write-Host "Setting service display name and description"
 run "{{ nssm_path }}" set {{ name }} DisplayName "Cloudify Agent - {{ name }}"
 run "{{ nssm_path }}" set {{ name }} Description "Cloudify Agent Service"
 
-Write-Output "Configuring startup policy..."
+Write-Host "Configuring startup policy..."
 Set-Service -Name {{ name }} -StartupType {{ startup_policy }}
 
-Write-Output "Configuring failure policy..."
+Write-Host "Configuring failure policy..."
 run $env:WINDIR\System32\sc.exe failure {{ name }} reset= {{ failure_reset_timeout }} actions= restart/{{ failure_restart_delay }}
 
-write-Output "Cloudify Agent configured successfully as a Windows Service ({{ name }})"
+Write-Host "Cloudify Agent configured successfully as a Windows Service ({{ name }})"

--- a/cloudify_agent/resources/script/windows-download.ps1.template
+++ b/cloudify_agent/resources/script/windows-download.ps1.template
@@ -35,17 +35,17 @@ $LogFile = $LogDir + "\{{ name }}-install.log"
 
 If (!(test-path $LogDir))
 {
-    Write-Output "Creating directory: $LogDir"
+    Write-Host "Creating directory: $LogDir"
     New-Item -ItemType Directory -Path $LogDir
 }
 
-Write-Output "Executing agent installer, log will be written to $LogFile"
+Write-Host "Executing agent installer, log will be written to $LogFile"
 .\agent_installer.ps1 *>> $LogFile
 if (!$?) {
-    Write-Output "Failed configuring agent (rc=$LASTEXITCODE)"
+    Write-Host "Failed configuring agent (rc=$LASTEXITCODE)"
     Exit 1
 }
 
-Write-Output "Agent installation completed"
+Write-Host "Agent installation completed"
 
 Remove-Item .\agent_installer.ps1 -Force

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -20,15 +20,15 @@ function run {
 {% if add_ssl_cert %}
 function AddSSLCert()
 {
-    Write-Output "Ensuring SSL Cert dir exists for {{ ssl_cert_path }}"
+    Write-Host "Ensuring SSL Cert dir exists for {{ ssl_cert_path }}"
     # Make sure the output directory exists
     New-Item -ItemType directory -Force -Path (Split-Path "{{ ssl_cert_path }}")
 
-    Write-Output "Adding SSL Cert to {{ ssl_cert_path }}"
+    Write-Host "Adding SSL Cert to {{ ssl_cert_path }}"
     # Create a new file with the certificate content
     New-Item "{{ ssl_cert_path }}" -type file -force -value "{{ ssl_cert_content }}"
 
-    Write-Output "Importing SSL cert from {{ ssl_cert_path }} to local machine root store"
+    Write-Host "Importing SSL cert from {{ ssl_cert_path }} to local machine root store"
     # Add the certificate to the root cert store
     Import-Certificate -FilePath "{{ ssl_cert_path }}" -CertStoreLocation Cert:\LocalMachine\Root
 }
@@ -38,14 +38,14 @@ function AddSSLCert()
 {% if install %}
 function Download($Url, $OutputPath)
 {
-    Write-Output "Downloading $URL to $OutputPath"
-    Write-Output "Ensuring download destination dir exists"
+    Write-Host "Downloading $URL to $OutputPath"
+    Write-Host "Ensuring download destination dir exists"
     # Make sure the output directory exists
     New-Item -ItemType directory -Force -Path (Split-Path $OutputPath)
 
-    Write-Output "Ensuring TLS 1.2 is used"
+    Write-Host "Ensuring TLS 1.2 is used"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-    Write-Output "Performing download with auth header"
+    Write-Host "Performing download with auth header"
     Invoke-RestMethod -Uri $Url -Headers @{ '{{ auth_token_header }}' = '{{ auth_token_value }}' } -OutFile $OutputPath
 }
 
@@ -55,15 +55,15 @@ function InstallAgent()
     AddSSLCert
     {% endif %}
     if (-Not (Test-Path "{{ conf.basedir }}\Scripts")) {
-        Write-Output "Installing cloudify agent package"
+        Write-Host "Installing cloudify agent package"
         Download "{{ conf.package_url }}" "{{ conf.basedir }}\cloudify-windows-agent-package.exe"
         # This call is not blocking so we pipe the output to null to make it blocking
         # There's no point trying to pipe it to not null because in the event it has problems it will
         # make a dialog box despite all the flags telling it we really want it to not do stuff like that.
-        Write-Output 'Starting install using "{{ conf.basedir }}\cloudify-windows-agent-package.exe"'
+        Write-Host 'Starting install using "{{ conf.basedir }}\cloudify-windows-agent-package.exe"'
         & "{{ conf.basedir }}\cloudify-windows-agent-package.exe" /SILENT /VERYSILENT /SUPPRESSMSGBOXES | Out-Null
     } else {
-        Write-Output "Agent package already installed"
+        Write-Host "Agent package already installed"
     }
 }
 {% endif %}
@@ -71,7 +71,7 @@ function InstallAgent()
 {% if configure %}
 function ExportDaemonEnv()
 {
-    Write-Output "Exporting daemon env"
+    Write-Host "Exporting daemon env"
     $env:Path = "{{ conf.basedir }}\Scripts;{{ conf.basedir }};" + $env:Path
     {% for env_key, env_value in daemon_env.items() %}
         $env:{{ env_key }} = "{{ env_value }}"
@@ -81,7 +81,7 @@ function ExportDaemonEnv()
 function CreateCustomEnvFile()
 {
     {% if custom_env is not none %}
-        Write-Output 'Populating custom env at "{{ custom_env_path }}"'
+        Write-Host 'Populating custom env at "{{ custom_env_path }}"'
         Set-Content "{{ custom_env_path }}" ""
         {% for env_key, env_value in custom_env.items() %}
              Add-Content "{{ custom_env_path }}" 'set {{ env_key }}="{{ env_value }}"'
@@ -96,9 +96,9 @@ function ConfigureAgent()
     ExportDaemonEnv
     CreateCustomEnvFile
 
-    Write-Output "Configuring agent..."
+    Write-Host "Configuring agent..."
     run "C:\Program Files\Cloudify Agents\Scripts\cfy-agent.exe" {{ debug_flag }} configure {{ configure_flags }}
-    Write-Output "Agent configured successfully"
+    Write-Host "Agent configured successfully"
 }
 {% endif %}
 
@@ -106,20 +106,20 @@ function ConfigureAgent()
 function StartAgent()
 {
     if (-Not (run "C:\Program Files\Cloudify Agents\Scripts\cfy-agent.exe" daemons list | Select-String $env:CLOUDIFY_DAEMON_NAME)) {
-        Write-Output "Creating daemon..."
+        Write-Host "Creating daemon..."
         run "C:\Program Files\Cloudify Agents\Scripts\cfy-agent.exe" {{ debug_flag }} daemons create {{ pm_options }}
-        Write-Output "Daemon created successfully"
+        Write-Host "Daemon created successfully"
     } else {
-        Write-Output "Agent already created, skipping create agent."
+        Write-Host "Agent already created, skipping create agent."
     }
 
-    Write-Output "Configuring daemon..."
+    Write-Host "Configuring daemon..."
     run "C:\Program Files\Cloudify Agents\Scripts\cfy-agent.exe" {{ debug_flag }} daemons configure
-    Write-Output "Daemon configured successfully"
+    Write-Host "Daemon configured successfully"
 
-    Write-Output "Starting daemon..."
+    Write-Host "Starting daemon..."
     run "C:\Program Files\Cloudify Agents\Scripts\cfy-agent.exe" {{ debug_flag }} daemons start
-    Write-Output "Daemon started successfully"
+    Write-Host "Daemon started successfully"
 }
 {% endif %}
 


### PR DESCRIPTION
Write-Output seems to result in swallowed logs when a failure occurs- possibly when a failure
occurs in the same block. Write-Host seems to reliably be captured by our logs.