### PR TITLE
Restrict agent build location

### DIFF
--- a/packaging/Jenkinsfile
+++ b/packaging/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent none
+    agent { label 'linux-agent-build' }
 
     parameters {
         string(name: 'VERSION', defaultValue: '', description: 'Cloudify version label, to be used in the filenames (eg. "5.1.0")')


### PR DESCRIPTION
They must run on the same node as the fetch_rhel_images job or problems will happen.