### PR TITLE
Do not fail due to no locale on sanity uninstall

### DIFF
--- a/cloudify_agent/shell/commands/cfy.py
+++ b/cloudify_agent/shell/commands/cfy.py
@@ -63,7 +63,7 @@ class CommandMixin(object):
             if os.name == "posix":
                 try:
                     locales = subprocess.Popen(
-                        ["locale", "-a"], stdout=subprocess.PIPE,
+                        ["/usr/bin/locale", "-a"], stdout=subprocess.PIPE,
                         stderr=subprocess.PIPE
                     ).communicate()[0]
                 except OSError:


### PR DESCRIPTION
Without this change, sanity-check's uninstall (and presumably other similar operations)
fails due to the 'locale' call returning an empty string.