### PR TITLE
RD-804 Re-release windows agent 5.1.0

### DIFF
--- a/cloudify_agent/tests/api/plugins/test_installer.py
+++ b/cloudify_agent/tests/api/plugins/test_installer.py
@@ -74,8 +74,8 @@ def test_uninstall_from_source(test_plugins, file_server):
         installer.install(plugins.plugin_struct(file_server,
                                                 source='mock-plugin.tar'))
     _assert_task_runnable('mock_plugin.tasks.run', expected_return='run')
-    installer.uninstall(plugin=plugins.plugin_struct(file_server))
     with _patch_client([]):
+        installer.uninstall(plugin=plugins.plugin_struct(file_server))
         _assert_task_not_runnable('mock_plugin.tasks.run')
 
 
@@ -90,9 +90,9 @@ def test_uninstall_from_source_with_deployment_id(test_plugins, file_server):
     _assert_task_runnable('mock_plugin.tasks.run',
                           expected_return='run',
                           deployment_id=deployment_id)
-    installer.uninstall(plugin=plugins.plugin_struct(file_server),
-                        deployment_id=deployment_id)
     with _patch_client([]):
+        installer.uninstall(plugin=plugins.plugin_struct(file_server),
+                            deployment_id=deployment_id)
         _assert_task_not_runnable('mock_plugin.tasks.run',
                                   deployment_id=deployment_id)
 

--- a/cloudify_agent/tests/utils.py
+++ b/cloudify_agent/tests/utils.py
@@ -136,11 +136,18 @@ def get_windows_built_agent_path():
 
 
 def create_windows_installer(config, logger):
-    version, prerelease = get_agent_version().split('-')
+    version_info = get_agent_version().split('-')
+    version = version_info[0]
+    if len(version_info) == 1:
+        prerelease = 'ga'
+        agent_name_suffix = version
+    else:
+        prerelease = version_info[1]
+        agent_name_suffix = '{0}-{1}'.format(version, prerelease)
 
     temp_agent_path = os.path.join(
         os.getcwd(),
-        'cloudify-windows-agent-{}-{}.exe'.format(version, prerelease)
+        'cloudify-windows-agent-{0}.exe'.format(agent_name_suffix)
     )
 
     if not os.path.exists(get_windows_built_agent_path()):

--- a/packaging/windows/packaging/create_install_wizard.iss
+++ b/packaging/windows/packaging/create_install_wizard.iss
@@ -1,6 +1,6 @@
 #define AppName "Cloudify Windows Agent"
+#define AppDisplayName GetEnv('DISPLAY_NAME')
 #define AppVersion GetEnv('VERSION')
-#define AppMilestone GetEnv('PRERELEASE')
 #define AppBuild GetEnv('BUILD')
 #define AppPublisher "Cloudify Platform Ltd."
 #define AppURL "https://cloudify.co/"
@@ -12,15 +12,14 @@ AppPublisher={#AppPublisher}
 AppPublisherURL={#AppURL}
 AppSupportURL={#AppURL}
 AppUpdatesURL={#AppURL}
-DefaultDirName={commonpf}\Cloudify {#AppVersion}-{#AppMilestone} Agents
+DefaultDirName={commonpf}\Cloudify {#AppDisplayName} Agents
 DisableProgramGroupPage=yes
 DisableDirPage=yes
-OutputBaseFilename=cloudify-windows-agent_{#AppVersion}-{#AppMilestone}
+OutputBaseFilename=cloudify-windows-agent_{#AppDisplayName}
 Compression=lzma
 SolidCompression=yes
 ArchitecturesInstallIn64BitMode=x64 arm64 ia64
 ArchitecturesAllowed=x64 arm64 ia64
-LicenseFile=source\license.txt
 MinVersion=6.0
 SetupIconFile=source\icons\Cloudify.ico
 UninstallDisplayIcon={app}\Cloudify.ico
@@ -30,11 +29,11 @@ OutputDir=output\
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "C:\Program Files\Cloudify {#AppVersion}-{#AppMilestone} Agents\*"; DestDir: "{app}"; Excludes: "\__pycache__\*"; Flags: createallsubdirs recursesubdirs
+Source: "C:\Program Files\Cloudify {#AppDisplayName} Agents\*"; DestDir: "{app}"; Excludes: "\__pycache__\*"; Flags: createallsubdirs recursesubdirs
 Source: "source\icons\Cloudify.ico"; DestDir: "{app}"
 
 [Tasks]
 Name: "desktopicon"; Description: "Create a desktop icon";
 
 [Icons]
-Name: "{commondesktop}\Cloudify {#AppVersion}-{#AppMilestone} Agents"; Filename: "{cmd}"; Parameters: "/k ""{app}\Scripts\activate.bat"""; WorkingDir: "{app}"; IconFilename: "{app}\Cloudify.ico"; Tasks: "desktopicon";
+Name: "{commondesktop}\Cloudify {#AppDisplayName} Agents"; Filename: "%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe";  Parameters: "-NoExit -Command $env:Path=\""{app}\Scripts\;$env:Path\""; function prompt {{\""[Cloudify {#AppDisplayName} Agents] $($executionContext.SessionState.Path.CurrentLocation)>\""}"; WorkingDir: "{app}"; IconFilename: "{app}\Cloudify.ico"; Tasks: "desktopicon";

--- a/packaging/windows/win_agent_builder.ps1
+++ b/packaging/windows/win_agent_builder.ps1
@@ -9,7 +9,12 @@ $ErrorActionPreference="stop"
 # Use TLSv1.2 for Invoke-Restmethod
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-$AGENT_PATH = "C:\Program Files\Cloudify $VERSION-$PRERELEASE Agents"
+$DISPLAY_NAME = $VERSION + '-' + $PRERELEASE
+$AGENT_PATH = "C:\Program Files\Cloudify $DISPLAY_NAME Agents"
+if ( $PRERELEASE -eq "ga" ) {
+   $AGENT_PATH = "C:\Program Files\Cloudify $VERSION Agents"
+   $DISPLAY_NAME = $VERSION
+}
 $GET_PIP_URL = "http://repository.cloudifysource.org/cloudify/components/win-cli-package-resources/get-pip-20.py"
 $PIP_VERSION = "9.0.1"
 $PY_URL = "https://repository.cloudifysource.org/cloudify/components/python-3.6.8-embed-amd64.zip"
@@ -106,7 +111,7 @@ popd
 
 Write-Host "Building agent package"
 $env:VERSION = $VERSION
-$env:PRERELEASE = $PRERELEASE
+$env:DISPLAY_NAME = $DISPLAY_NAME
 run "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" cloudify-agent\packaging\windows\packaging\create_install_wizard.iss
 
 if ( $UPLOAD -eq "upload" ) {

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,8 @@
-https://github.com/cloudify-cosmo/cloudify-common/archive/5.1.0.zip#egg=cloudify-cosmo[dispatcher]
+https://github.com/cloudify-cosmo/cloudify-common/archive/5.1.0.zip#egg=cloudify-common[dispatcher]
 mock==1.0.1
 pywinrm==0.4.1
-cryptography==2.1.4
+cryptography>=3.1.1,<3.2
+requests>=2.9.1,<3.0.0
 
 #for python 2.6 support
 xmltodict==0.11.0
@@ -9,5 +10,6 @@ idna==2.7
 
 # for creating the agent package in tests
 https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/master.zip
-pytest
-pytest-cov
+pytest==6.2.0
+coverage==5.3
+pytest-cov==2.10.1


### PR DESCRIPTION
The main purpose of this change is to fix the issue for building the windows agent and also make the tests passed on branch 5.1.0-build by adding all the required CI files so that it can be run on jenkins. Moreover, the name of the windows agent for GA release is not going to have a `ga` suffix`