### PR TITLE
Use a different app name for different win agents

### DIFF
--- a/packaging/windows/packaging/create_install_wizard.iss
+++ b/packaging/windows/packaging/create_install_wizard.iss
@@ -1,4 +1,3 @@
-#define AppName "Cloudify Windows Agent"
 #define AppDisplayName GetEnv('DISPLAY_NAME')
 #define AppVersion GetEnv('VERSION')
 #define AppBuild GetEnv('BUILD')
@@ -6,7 +5,7 @@
 #define AppURL "https://cloudify.co/"
 
 [Setup]
-AppName={#AppName}
+AppName={#AppDisplayName}
 AppVersion={#AppVersion}
 AppPublisher={#AppPublisher}
 AppPublisherURL={#AppURL}


### PR DESCRIPTION
Otherwise they will try to install to the same location and the sky will fall down.