### PR TITLE
RD-928 Cope with malformed agent json (#732)

### DIFF
--- a/cloudify_agent/api/factory.py
+++ b/cloudify_agent/api/factory.py
@@ -138,11 +138,18 @@ class DaemonFactory(object):
                 daemon_file
             )
             if full_path.endswith('json'):
-                self.logger.debug('Loading daemon from: {0}'.format(full_path))
-                daemon_as_json = utils.json_load(full_path)
-                process_management = daemon_as_json.pop('process_management')
-                daemon = DaemonFactory._find_implementation(process_management)
-                daemons.append(daemon(logger=logger, **daemon_as_json))
+                try:
+                    self.logger.debug('Loading daemon from: %s', full_path)
+                    daemon_as_json = utils.json_load(full_path)
+                    process_management = daemon_as_json.pop(
+                        'process_management')
+                    daemon = DaemonFactory._find_implementation(
+                        process_management)
+                    daemons.append(daemon(logger=logger, **daemon_as_json))
+                except KeyError as err:
+                    self.logger.warning(
+                        'Daemon from %s load failed: %s', full_path, err,
+                    )
 
         return daemons
 


### PR DESCRIPTION
Specifically, 4.6 seems to create some that don't have the process_management key.
However, this will also cope with any other old/broken agent configs.