### PR TITLE
RD-1007 Fix issue with access home directory for agent using centos 8…

### DIFF
--- a/cloudify_agent/installer/config/agent_config.py
+++ b/cloudify_agent/installer/config/agent_config.py
@@ -371,10 +371,8 @@ class CloudifyAgentConfig(dict):
         else:
             if self.is_windows:
                 basedir = get_windows_basedir()
-            elif self.is_remote:
-                basedir = runner.home_dir(self['user'])
             else:
-                basedir = '~{0}'.format(self['user'])
+                basedir = get_linux_basedir()
         self['basedir'] = basedir
 
     def set_config_paths(self):
@@ -521,3 +519,7 @@ def get_windows_basedir():
     # Or maybe we shouldn't- see RD-882
     return 'C:\\Program Files\\Cloudify {} Agents'.format(
         agent_utils.get_agent_version())
+
+
+def get_linux_basedir():
+    return '/opt/cloudify-agent-{0}'.format(agent_utils.get_agent_version())

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -186,6 +186,7 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         )
         if not self.cloudify_agent.is_windows:
             args_dict['user'] = self.cloudify_agent['user']
+            args_dict['agent_dir'] = self.cloudify_agent['agent_dir']
         return template.render(**args_dict)
 
     def _cleanup_after_installation(self, path):

--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -8,11 +8,27 @@ run_as()
     user=$1
     if [ "$MYSELF" == "$user" ]
     then
-        ${@:2}
+        sg cfyagent "${@:2}"
     else
         su $user --shell /bin/bash -c "set -e; ${@:2}"
     fi
 }
+
+configure_agent_installation()
+{
+   # Create cfyagent group so that we can assign it user that execute and install agent
+   # to that group so that they can have access to `/opt/cloudify-agent-{version}`
+   user_groups="$(groups {{ user }})"
+   grep -q -e 'cfyagent' /etc/group || sudo groupadd cfyagent
+   grep -q -e 'cfyagent' <<< "$user_groups" || sudo usermod -a -G cfyagent {{ user }}
+
+   # Prepare and create agent directory and provide write permission to users belongs to cfyagent group
+   sudo mkdir -p {{ agent_dir }}
+   sudo chgrp -R cfyagent $(dirname {{ agent_dir }})
+   sudo chmod -R g+w $(dirname {{ agent_dir }})
+}
+
+export -f configure_agent_installation
 
 add_ssl_cert()
 {
@@ -51,8 +67,9 @@ cd $(mktemp -d)
 # If using `sudo` the script is running as a user, and there's no need
 # to use `su`. If running as root, `su` as the user, otherwise the cert
 # dir will be created with root privileges
+configure_agent_installation
 {% if sudo %}
-add_ssl_cert
+sg cfyagent "add_ssl_cert"
 {% else %}
 run_as {{ user }} add_ssl_cert
 {% endif %}

--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -18,9 +18,8 @@ configure_agent_installation()
 {
    # Create cfyagent group so that we can assign it user that execute and install agent
    # to that group so that they can have access to `/opt/cloudify-agent-{version}`
-   user_groups="$(groups {{ user }})"
-   grep -q -e 'cfyagent' /etc/group || sudo groupadd cfyagent
-   grep -q -e 'cfyagent' <<< "$user_groups" || sudo usermod -a -G cfyagent {{ user }}
+   sudo groupadd -f cfyagent
+   sudo usermod -a -G cfyagent {{ user }}
 
    # Prepare and create agent directory and provide write permission to users belongs to cfyagent group
    sudo mkdir -p {{ agent_dir }}

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -17,9 +17,8 @@ configure_agent_installation()
 {
    # Create cfyagent group so that we can assign it user that execute and install agent
    # to that group so that they can have access to `/opt/cloudify-agent-{version}`
-   user_groups="$(groups {{ conf.user }})"
-   grep -q -e 'cfyagent' /etc/group || sudo groupadd cfyagent
-   grep -q -e 'cfyagent' <<< "$user_groups" || sudo usermod -a -G cfyagent {{ conf.user }}
+   sudo groupadd -f cfyagent
+   sudo usermod -a -G cfyagent {{ conf.user }}
 
    # Prepare and create agent directory and provide write permission to users belongs to cfyagent group
    sudo mkdir -p {{ conf.agent_dir }}

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -7,11 +7,27 @@ run_as()
     user=$1
     if [ "$MYSELF" == "$user" ]
     then
-        ${@:2}
+        sg cfyagent ${@:2}
     else
         su $user --shell /bin/bash -c "set -e; ${@:2}"
     fi
 }
+
+configure_agent_installation()
+{
+   # Create cfyagent group so that we can assign it user that execute and install agent
+   # to that group so that they can have access to `/opt/cloudify-agent-{version}`
+   user_groups="$(groups {{ conf.user }})"
+   grep -q -e 'cfyagent' /etc/group || sudo groupadd cfyagent
+   grep -q -e 'cfyagent' <<< "$user_groups" || sudo usermod -a -G cfyagent {{ conf.user }}
+
+   # Prepare and create agent directory and provide write permission to users belongs to cfyagent group
+   sudo mkdir -p {{ conf.agent_dir }}
+   sudo chgrp -R cfyagent $(dirname {{ conf.agent_dir }})
+   sudo chmod -R g+w $(dirname {{ conf.agent_dir }})
+}
+
+export -f configure_agent_installation
 
 {% if add_ssl_cert %}
 add_ssl_cert()
@@ -85,7 +101,6 @@ download_and_extract_agent_package()
     temp_pkg_dir=$(mktemp -d)
     pkg_loc=${temp_pkg_dir}/agent.tar.gz
     download $(package_url) ${pkg_loc}
-    mkdir -p {{ conf.agent_dir }}
     tar xzf ${pkg_loc} --strip=1 -C {{ conf.agent_dir }}
     rm -rf ${temp_pkg_dir}
 }
@@ -93,6 +108,7 @@ export -f download_and_extract_agent_package
 
 install_agent()
 {
+    configure_agent_installation
     {% if add_ssl_cert %}
     run_as {{ conf.user }} add_ssl_cert
     {% endif %}


### PR DESCRIPTION
This PR added so that we can avoid any selinux permission issue raised when trying to install agent on redhat/centos 8 version where a permission denied issue appeared related to preventing systemd init process from accessing the home directory for the installed agent. where the issue happened when starting the agent daemon [start daemon](https://github.com/cloudify-cosmo/cloudify-agent/blob/master/cloudify_agent/resources/script/linux.sh.template#L166)  where it configure the systemd required files for agent so that it can be controlled and running with systemctl and run when machine get rebooted.

The starter command for that service will try to start the host agent that located under `/home/centos` or `/home/cloud-user` directory and when this try to get started it failed because of permission issues raised by selinux.