### PR TITLE
linux.sh.template: also lowercase the codename

### DIFF
--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -90,7 +90,7 @@ package_url()
     else
         local python_bin=$(which python || which python3)
         local distro="$($python_bin -c 'import sys, platform; sys.stdout.write(platform.dist()[0].lower())')"
-        local distro_codename="$($python_bin -c 'import sys, platform; data = platform.dist(); version = data[1].split(".")[0]; codename = version if data[0] == "centos" and version == "8" else data[2]; sys.stdout.write(codename)')"
+        local distro_codename="$($python_bin -c 'import sys, platform; data = platform.dist(); version = data[1].split(".")[0]; codename = version if data[0] == "centos" and version == "8" else data[2]; sys.stdout.write(codename.lower())')"
         echo "{{ file_server_url }}/packages/agents/${distro}-${distro_codename}-agent.tar.gz"
     fi
 }


### PR DESCRIPTION
It used to be lowercased before, but #724 lost the `.lower()` call, which
makes agents impossible to be downloaded and installed.