### PR TITLE
Convert distro name to lower before generate package url for agent

### DIFF
--- a/cloudify_agent/installer/config/agent_config.py
+++ b/cloudify_agent/installer/config/agent_config.py
@@ -441,7 +441,7 @@ class CloudifyAgentConfig(dict):
             if distro[0] == "centos" and version == "8":
                 distro_codename = version
 
-            self['distro_codename'] = distro_codename
+            self['distro_codename'] = distro_codename.lower()
 
 
 def _get_agent_inputs(params):


### PR DESCRIPTION
This PR created to fix issue with download agent from file server where it distro name should be  first converted  to lower case so the correct agent should be picked up correctly