### PR TITLE
RD-1287 Pika version upgrade

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,2 @@
 https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip
+pika==1.1.0


### PR DESCRIPTION
Since the agent for RHEL6/Python 2.6 uses its own dev-requirements.txt
we may try bumping the version to the most recent one for all other
builds.