### PR TITLE
RD-1345 Use pika 0.11.2 for python version < 2.7.9

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,1 @@
 https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip
-pika==1.1.0


### PR DESCRIPTION
We add a constraint on the cloudify common so that we can install the suitable pika version for python version where we always used/install pika == 0.11.2 for python >=2.6 or python < 2.7.9 and since dev-req.txt already have reference to common so no need to pin/install the pika again on the dev-req.txt