### PR TITLE
RD-1387 Make sure to always use the new agent location when upgrade a…

### DIFF
--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -176,6 +176,8 @@ def _copy_values_from_old_agent_config(old_agent, new_agent):
             new_agent[field] = old_agent[field]
     if new_agent['windows']:
         new_agent['basedir'] = utils.get_windows_basedir()
+    else:
+        new_agent['basedir'] = utils.get_linux_basedir()
 
 
 def create_new_agent_config(old_agent):

--- a/cloudify_agent/tests/test_operations.py
+++ b/cloudify_agent/tests/test_operations.py
@@ -21,12 +21,12 @@ def test_create_agent_dict(agent_ssl_cert, tmp_path):
         new_agent = operations.create_new_agent_config(old_agent)
         new_agent['version'] = '3.4'
         third_agent = operations.create_new_agent_config(new_agent)
-        equal_keys = ['ip', 'basedir', 'user']
+        equal_keys = ['ip', 'user']
         for k in equal_keys:
             assert old_agent[k] == new_agent[k]
             assert old_agent[k] == third_agent[k]
         nonequal_keys = ['agent_dir', 'workdir', 'envdir', 'name',
-                         'rest_host']
+                         'rest_host', 'basedir']
         for k in nonequal_keys:
             assert old_agent[k] != new_agent[k]
             assert old_agent[k] != third_agent[k]


### PR DESCRIPTION
This PR added in order to make sure that the agent upgrade installation from old version of cloudify < 5.2.0 to 5.2.0 will for linux agent VM should be always reside inside the `/opt/cloudify-agent-{VERSION}` so that we can avoid any permission issues 