### PR TITLE
RD-1707 Handle deployment update failure

### DIFF
--- a/cloudify_agent/api/pm/base.py
+++ b/cloudify_agent/api/pm/base.py
@@ -20,6 +20,8 @@ import logging
 import os
 import time
 
+from pika.exceptions import ConnectionClosed
+
 from cloudify.utils import (LocalCommandRunner,
                             setup_logger)
 from cloudify import constants
@@ -335,16 +337,20 @@ class Daemon(object):
     def _is_daemon_running(self):
         self._logger.debug('Checking if agent daemon is running...')
         client = self._get_client()
-        with client:
-            # precreate the queue that the agent will use, so that the
-            # message is already waiting for the agent when it starts up
-            client.channel_method(
-                'queue_declare',
-                queue='{0}_service'.format(self.queue),
-                auto_delete=False,
-                durable=True)
-            return utils.is_agent_alive(
-                self.queue, client, timeout=3, connect=False)
+        try:
+            with client:
+                # precreate the queue that the agent will use, so that the
+                # message is already waiting for the agent when it starts up
+                client.channel_method(
+                    'queue_declare',
+                    queue='{0}_service'.format(self.queue),
+                    auto_delete=False,
+                    durable=True)
+                return utils.is_agent_alive(
+                    self.queue, client, timeout=3, connect=False)
+        except ConnectionClosed:
+            self._logger.debug('Connection was closed, AMQP is unreachable.')
+            return False
 
     ########################################################################
     # the following methods must be implemented by the sub-classes as they

--- a/cloudify_agent/installer/operations.py
+++ b/cloudify_agent/installer/operations.py
@@ -1,18 +1,3 @@
-#########
-# Copyright (c) 2015 GigaSpaces Technologies Ltd. All rights reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  * See the License for the specific language governing permissions and
-#  * limitations under the License.
-
 from cloudify.decorators import operation
 from cloudify.amqp_client import get_client
 from cloudify.models_states import AgentState
@@ -48,6 +33,12 @@ def create(cloudify_agent, installer, **_):
                 ctx.logger.error("Failed creating agent; marking agent as "
                                  "failed")
                 update_agent_record(cloudify_agent, AgentState.FAILED)
+                try:
+                    ctx.logger.info('Attempting to cleanup after agent %s',
+                                    cloudify_agent['name'])
+                    installer.delete_agent()
+                except Exception as err:
+                    ctx.logger.info('Deletion failed: %s', err)
                 raise
             ctx.logger.info(
                 'Agent created, configured and started successfully'


### PR DESCRIPTION
When doing a deployment update on a pre-existing host, we try to reuse
the agent name, which can cause failures if a snapshot restore has been
run and the old manager removed, so we will work around that by trying
to remove the agent if an install fails.