### PR TITLE
RD-2625 If cron_respawn is false, don't enable it

### DIFF
--- a/cloudify_agent/api/pm/base.py
+++ b/cloudify_agent/api/pm/base.py
@@ -768,7 +768,6 @@ class CronRespawnDaemonMixin(Daemon):
             self.workdir, '{0}-respawn.sh'.format(self.name))
 
     def create_enable_cron_script(self):
-
         enable_cron_script = os.path.join(
             self.workdir, '{0}-enable-cron.sh'.format(self.name))
 
@@ -793,7 +792,6 @@ class CronRespawnDaemonMixin(Daemon):
         return enable_cron_script
 
     def create_disable_cron_script(self):
-
         disable_cron_script = os.path.join(
             self.workdir, '{0}-disable-cron.sh'.format(self.name))
 

--- a/cloudify_agent/api/pm/detach.py
+++ b/cloudify_agent/api/pm/detach.py
@@ -57,11 +57,13 @@ class DetachedDaemon(CronRespawnDaemonMixin):
 
         # add cron job to re-spawn the process
         self._logger.debug('Adding cron JOB')
-        self._runner.run(self.create_enable_cron_script())
+        if self.cron_respawn:
+            self._runner.run(self.create_enable_cron_script())
 
     def before_self_stop(self):
         self._logger.debug('Removing cron JOB')
-        self._runner.run(self.create_disable_cron_script())
+        if self.cron_respawn:
+            self._runner.run(self.create_disable_cron_script())
         super(DetachedDaemon, self).before_self_stop()
 
     def _delete_queue(self, client):


### PR DESCRIPTION
* RD-2625 If cron_respawn is false, don't enable it

Why would we always enable it?

* actually, only do it in the detach agent

the initd agent already has its own logic, in the bash script,
where it calls the script or not.

So, do it on the same level, in the detach agent.