### PR TITLE
RD-2966 Use os.pathsep for creating PATH

### DIFF
--- a/cloudify_agent/worker.py
+++ b/cloudify_agent/worker.py
@@ -323,8 +323,9 @@ class CloudifyOperationConsumer(TaskConsumer):
             else:
                 executable = sys.executable
 
-            env['PATH'] = '{0}:{1}'.format(
-                os.path.dirname(executable), env['PATH'])
+            env['PATH'] = os.pathsep.join([
+                os.path.dirname(executable), env['PATH']
+            ])
             command_args = [executable, '-u', '-m', 'cloudify.dispatch',
                             dispatch_dir]
             self.run_subprocess(ctx, command_args,


### PR DESCRIPTION
It won't be `:` on windows.