### PR TITLE
WDR-77 Fix the way curl handles the `::1` address

### DIFF
--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -30,7 +30,7 @@ from jinja2 import Template
 from cloudify._compat import urlquote, PY2
 from cloudify.cluster import CloudifyClusterClient
 from cloudify.workflows import tasks as workflows_tasks
-from cloudify.utils import setup_logger, get_exec_tempdir
+from cloudify.utils import setup_logger, get_exec_tempdir, ipv6_url_compat
 from cloudify.constants import (SECURED_PROTOCOL,
                                 BROKER_PORT_SSL,
                                 BROKER_PORT_NO_SSL)
@@ -474,7 +474,8 @@ def _parse_comma_separated(ctx, param, value):
 def get_manager_file_server_url(hostname, port, scheme=None):
     if scheme is None:
         scheme = 'http' if port == 80 else 'https'
-    return '{0}://{1}:{2}/resources'.format(scheme, hostname, port)
+    return '{0}://{1}:{2}/resources'.format(
+        scheme, ipv6_url_compat(hostname), port)
 
 
 def get_agent_version():

--- a/cloudify_agent/resources/script/linux-download.sh.template
+++ b/cloudify_agent/resources/script/linux-download.sh.template
@@ -55,7 +55,7 @@ download()
     if command -v wget > /dev/null 2>&1; then
         wget {{ link }} -O ${SCRIPT_NAME} -nv --ca-certificate {{ ssl_cert_path }}
     elif command -v curl > /dev/null 2>&1; then
-        STATUS_CODE=$(curl -L -o ${SCRIPT_NAME} --write-out "%{http_code}" {{ link }} --cacert {{ ssl_cert_path }})
+        STATUS_CODE=$(curl -g -L -o ${SCRIPT_NAME} --write-out "%{http_code}" {{ link }} --cacert {{ ssl_cert_path }})
         if [ "${STATUS_CODE}" -ne "200" ] ; then
             echo >&2 "Received unexpected HTTP response code (${STATUS_CODE}). Response data was saved into ${SCRIPT_NAME}."
             return 1

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -80,7 +80,7 @@ download()
     if command -v wget > /dev/null 2>&1; then
         wget $1 -O $2 --header="{{ auth_token_header }}: {{ auth_token_value }}" -nv --ca-certificate {{ ssl_cert_path }}
     elif command -v curl > /dev/null 2>&1; then
-        STATUS_CODE=$(curl -L -o $2 --write-out "%{http_code}" $1 -H "{{ auth_token_header }}: {{ auth_token_value }}" --cacert {{ ssl_cert_path }})
+        STATUS_CODE=$(curl -g -L -o $2 --write-out "%{http_code}" $1 -H "{{ auth_token_header }}: {{ auth_token_value }}" --cacert {{ ssl_cert_path }})
         if [ "${STATUS_CODE}" -ne "200" ] ; then
             echo >&2 "Received unexpected HTTP response code (${STATUS_CODE}). Response data was saved into $2."
             return 1


### PR DESCRIPTION
Without that patch, curl (7.29.0) didn't properly recognize IPv6
localhost (`::1`) address when combined with a port number (`:53333`).