### PR TITLE
Upgrade celery to version 4.4.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ setup(
             'python-gssapi==0.6.4'
         ],
         'celery': [
-            'celery==3.1.17',
+            'celery==4.4.7',
         ],
         'fabric': [
             'fabric==2.5.0',


### PR DESCRIPTION
It's the last version which supports Python 2.7.

This way we drop anyjson dependency (which is broken as of 2021-09-07).