### PR TITLE
RD-3307 Set symlinks for windows ctx and cfy-agent

### DIFF
--- a/packaging/windows/win_agent_builder.ps1
+++ b/packaging/windows/win_agent_builder.ps1
@@ -109,6 +109,10 @@ pushd cloudify-agent
     run $AGENT_PATH\scripts\pip.exe install --prefix="$AGENT_PATH" .
 popd
 
+Write-Host "Adding ctx and cfy-agent symlinks..."
+New-Item -ItemType SymbolicLink -Path "$AGENT_PATH\ctx.exe" -Value "$AGENT_PATH\Scripts\ctx.exe"
+New-Item -ItemType SymbolicLink -Path "$AGENT_PATH\cfy-agent.exe" -Value "$AGENT_PATH\Scripts\cfy-agent.exe"
+
 Write-Host "Building agent package"
 $env:VERSION = $VERSION
 $env:DISPLAY_NAME = $DISPLAY_NAME


### PR DESCRIPTION
These are now out of path because nssm starts with the embedded python
directory in path (as that's where it runs), but not the scripts subdir.
Previously this worked because python.exe was in the scripts subdir.