### PR TITLE
RD-3298 create internal build images

### DIFF
--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -115,7 +115,7 @@ pipeline {
                       popd
                       cfy deployments capabilities ec2-cfy-agent-tests-blueprint-${env.BRANCH_NAME}-${env.BUILD_NUMBER} --json > capabilities.json
                       jq -r '.key_content.value' capabilities.json > ~/.ssh/ec2_ssh_key && chmod 600 ~/.ssh/ec2_ssh_key
-                      sleep 120
+                      sleep 160
                       ssh-keyscan -H \$(jq -r '.endpoint.value' capabilities.json) >> ~/.ssh/known_hosts
                       echo 'ClientAliveInterval 50' >> /etc/ssh/sshd_config
                     """, label:'Configure and install blueprint on manager'

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -180,7 +180,7 @@ EOT
           steps {
             container('rpmbuild'){
               sh script: """
-                cd rpmbuild
+                cd ~/rpmbuild
                 git clone https://github.com/cloudify-cosmo/cloudify-agent.git SOURCES && cd SOURCES && git checkout ${env.BRANCH_NAME}
               """, label: 'Copying repo to seperate workspace'
               sh script: """

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
   options {
     checkoutToSubdirectory('cloudify-agent')
     buildDiscarder(logRotator(numToKeepStr:'10'))
-    timeout(time: 60, unit: 'MINUTES')
+    timeout(time: 90, unit: 'MINUTES')
     timestamps()
   }
   environment {

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -78,6 +78,10 @@ pipeline {
             sh script: "mkdir -p ${env.WORKSPACE}/build_agent && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/build_agent", label: "copying repo to seperate workspace"
             container('rpmbuild'){
               dir("${env.WORKSPACE}/build_agent") {
+                sh script: '''
+                  curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py | python
+                  python get-pip.py
+                  ''', label: 'installing pip'
                 sh script: 'pip install https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/master.zip', label: 'installing agent packager'
                 sh script: '''
                   cp packaging/local.ini centos7.ini
@@ -111,7 +115,7 @@ pipeline {
                       popd
                       cfy deployments capabilities ec2-cfy-agent-tests-blueprint-${env.BRANCH_NAME}-${env.BUILD_NUMBER} --json > capabilities.json
                       jq -r '.key_content.value' capabilities.json > ~/.ssh/ec2_ssh_key && chmod 600 ~/.ssh/ec2_ssh_key
-                      sleep 160
+                      sleep 120
                       ssh-keyscan -H \$(jq -r '.endpoint.value' capabilities.json) >> ~/.ssh/known_hosts
                       echo 'ClientAliveInterval 50' | sudo tee --append /etc/ssh/sshd_config
                     """, label:'Configure and install blueprint on manager'

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -76,13 +76,8 @@ pipeline {
         stage('build_agent'){
           steps{
             sh script: "mkdir -p ${env.WORKSPACE}/build_agent && cp -rf ${env.WORKSPACE}/${env.PROJECT}/. ${env.WORKSPACE}/build_agent", label: "copying repo to seperate workspace"
-            container('centos7'){
+            container('rpmbuild'){
               dir("${env.WORKSPACE}/build_agent") {
-                sh script: '''
-                  curl -O https://bootstrap.pypa.io/pip/2.7/get-pip.py | python
-                  python get-pip.py
-                  yum install -y python-devel git gcc gcc-c++
-                  ''', label: 'installing prerequisities'
                 sh script: 'pip install https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/master.zip', label: 'installing agent packager'
                 sh script: '''
                   cp packaging/local.ini centos7.ini
@@ -109,8 +104,6 @@ pipeline {
                       set -euxo pipefail
                       python -m venv .venv
                       source .venv/bin/activate
-                      pip install --upgrade pip==20.3.4
-                      pip install cloudify==5.2.4
 
                       cfy profile use ${env.MANAGER_IP} -u ${env.MANAGER_USERNAME} -p ${env.MANAGER_PASSWORD} -t ${env.MANAGER_TENANT} --ssl
                       pushd 'bp'
@@ -132,7 +125,7 @@ pipeline {
     }
     stage('pytest and build rpm'){
       parallel {
-        stage('Configure & Run-tests py27 on EC2 instance'){
+        stage('Configure & Run-tests on EC2 instance'){
           steps{
             catchError(message: 'Failure on: cloudify-agent tests', buildResult: 'SUCCESS', stageResult: 'FAILURE') {
               container('py36'){
@@ -154,6 +147,7 @@ git checkout ${env.BRANCH_NAME}
 pip install -r test-requirements.txt
 pip install -r dev-requirements.txt
 pip install '.[fabric]'
+echo 'run py2.7 tests'
 pytest --run-rabbit-tests --run-ci-tests --cov-report term-missing --cov=cloudify_agent cloudify_agent --junitxml=test-results/cloudify_agent_py2.xml
 popd
 deactivate
@@ -166,6 +160,7 @@ pushd cloudify-agent
 pip install -r test-requirements.txt
 pip install -r dev-requirements.txt
 pip install '.[fabric]'
+echo 'run py3.6 tests'
 pytest --run-rabbit-tests --run-ci-tests --cov-report term-missing --cov=cloudify_agent cloudify_agent --junitxml=test-results/cloudify_agent_py3.xml
 popd
 deactivate
@@ -181,11 +176,10 @@ EOT
           steps {
             container('rpmbuild'){
               sh script: """
-                cd && mkdir rpmbuild && cd rpmbuild
+                cd rpmbuild
                 git clone https://github.com/cloudify-cosmo/cloudify-agent.git SOURCES && cd SOURCES && git checkout ${env.BRANCH_NAME}
               """, label: 'Copying repo to seperate workspace'
               sh script: """
-                chmod a+wx /opt
                 curl -o ~/rpmbuild/SOURCES/cloudify-agents.spec https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/master/packaging/cloudify-agents.spec ;
                 mkdir -p ~/rpmbuild/SOURCES/packaging/agents/ ;
                 curl -o ~/rpmbuild/SOURCES/packaging/agents/copy_packages.py https://raw.githubusercontent.com/cloudify-cosmo/cloudify-manager/master/packaging/agents/copy_packages.py ;
@@ -194,7 +188,6 @@ EOT
                 cd ~/rpmbuild/SOURCES
                 cp -rf ${env.WORKSPACE}/build_agent/*.tar.gz .
 
-                yum install rpmdevtools -y
                 for i in {1..30}; do yum-builddep -y cloudify-agents.spec && break || sleep 10; done
 
                 spectool \

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
                       jq -r '.key_content.value' capabilities.json > ~/.ssh/ec2_ssh_key && chmod 600 ~/.ssh/ec2_ssh_key
                       sleep 120
                       ssh-keyscan -H \$(jq -r '.endpoint.value' capabilities.json) >> ~/.ssh/known_hosts
-                      echo 'ClientAliveInterval 50' | sudo tee --append /etc/ssh/sshd_config
+                      echo 'ClientAliveInterval 50' >> /etc/ssh/sshd_config
                     """, label:'Configure and install blueprint on manager'
                   }
                 }

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -18,13 +18,13 @@ spec:
       privileged: true
     resources:
       requests:
-        cpu: 1
-        memory: 3Gi
+        cpu: 0.5
+        memory: 1.5Gi
       limits:
-        cpu: 1
-        memory: 3Gi
+        cpu: 0.5
+        memory: 1.5Gi
   - name: py36
-    image: circleci/python:3.6
+    image: 263721492972.dkr.ecr.eu-west-1.amazonaws.com/cloudify-python3.6
     command:
     - cat
     tty: true
@@ -35,20 +35,8 @@ spec:
       limits:
         cpu: 1
         memory: 1Gi
-  - name: centos7
-    image: centos:7
-    command:
-    - cat
-    tty: true
-    securityContext:
-      runAsUser: 0
-      privileged: true
-    resources:
-      limits:
-        cpu: 0.5
-        memory: 512Mi
   - name: rpmbuild
-    image: rpmbuild/centos7
+    image: 263721492972.dkr.ecr.eu-west-1.amazonaws.com/cloudify-rpmbuild
     command:
     - cat
     tty: true
@@ -57,8 +45,8 @@ spec:
       privileged: true
     resources:
       limits:
-        cpu: 0.3
-        memory: 256Mi
+        cpu: 1
+        memory: 1Gi
   - name: awscli
     image: amazon/aws-cli
     command:


### PR DESCRIPTION
Switch to new internal build images to cut CI time.
Also increase timeout due to long windows stage.
Changed build pod yaml accordingly.
