### PR TITLE
RD-3946 Don't leak bypass_maintenance between executions

### DIFF
--- a/cloudify_agent/worker.py
+++ b/cloudify_agent/worker.py
@@ -325,8 +325,6 @@ class CloudifyOperationConsumer(TaskConsumer):
         # directory that only lives during the lifetime of the subprocess
         dispatch_dir = None
         try:
-            if ctx.bypass_maintenance:
-                os.environ[constants.BYPASS_MAINTENANCE] = 'True'
             env = self._build_subprocess_env(ctx)
 
             if self._uses_external_plugin(ctx):

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ setup(
         ],
         'fabric': [
             'fabric==2.5.0',
+            'pynacl==1.4.0',
         ]
     }
 )


### PR DESCRIPTION
Obviously, if we set it in the environ, and never set it back, that's
no bueno.

Funnily, we don't even need it here, because in the current process,
it's already set on ctx; and we pass it to child processes explicitly,
when creating _their_ env.