### PR TITLE
pin jinja2 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 install_requires = [
     'cloudify-common==6.4.0.dev1',
     'appdirs==1.4.3',
-    'jinja2>=2.10,<2.11',
+    'jinja2==2.11.3',
     'virtualenv==15.1.0',
     'click>7,<8',
     'packaging==17.1',


### PR DESCRIPTION
pin jinja2 version to 2.13 for two reasons:
1. to fix vulnerability: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28493
2. to match with cloudify-common pinned jinja2 version