### PR TITLE
RD-4923 Error out on empty daemon name

### DIFF
--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -145,7 +145,10 @@ def _load_daemon(logger):
     factory = DaemonFactory(
         username=utils.internal.get_daemon_user(),
         storage=utils.internal.get_daemon_storage_dir())
-    return factory.load(get_daemon_name(), logger=logger)
+    name = get_daemon_name()
+    if name is None:
+        raise RuntimeError('Agent name not set')
+    return factory.load(name, logger=logger)
 
 
 def _save_daemon(daemon):


### PR DESCRIPTION
In cloudify-cosmo/cloudify-common#1055 I've made it so that
gat_daemon_name returns None if the envvar is missing. Let's abort
then, so that we don't attempt to read None.json