### PR TITLE
RD-5553 Windows jnlp agent connectivity ci

### DIFF
--- a/cloudify_agent/tests/resources/blueprints/agent-from-package/local-agent-blueprint.yaml
+++ b/cloudify_agent/tests/resources/blueprints/agent-from-package/local-agent-blueprint.yaml
@@ -1,4 +1,4 @@
-tosca_definitions_version: cloudify_dsl_1_3
+tosca_definitions_version: cloudify_dsl_1_4
 
 imports:
   - http://www.getcloudify.org/spec/cloudify/7.0.0.dev1/types.yaml

--- a/cloudify_agent/tests/resources/blueprints/install-agent/test-install-agent-blueprint-windows.yaml
+++ b/cloudify_agent/tests/resources/blueprints/install-agent/test-install-agent-blueprint-windows.yaml
@@ -1,4 +1,4 @@
-tosca_definitions_version: cloudify_dsl_1_3
+tosca_definitions_version: cloudify_dsl_1_4
 
 imports:
     - http://www.getcloudify.org/spec/cloudify/7.0.0.dev1/types.yaml

--- a/cloudify_agent/tests/resources/blueprints/install-agent/test-install-agent-blueprint.yaml
+++ b/cloudify_agent/tests/resources/blueprints/install-agent/test-install-agent-blueprint.yaml
@@ -1,4 +1,4 @@
-tosca_definitions_version: cloudify_dsl_1_3
+tosca_definitions_version: cloudify_dsl_1_4
 
 imports:
     - http://www.getcloudify.org/spec/cloudify/7.0.0.dev1/types.yaml

--- a/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
+++ b/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 description: >
   This blueprint deploy EC2 for agent tests
 imports:
-  - http://cloudify.co/spec/cloudify/6.4.0/types.yaml # temp old types until we upgrade CI manager
+  - http://cloudify.co/spec/cloudify/6.3.0/types.yaml # temp old types until we upgrade CI manager
   - plugin:cloudify-aws-plugin?version= >=3.0.3
   - plugin:cloudify-utilities-plugin
 

--- a/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
+++ b/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
@@ -1,4 +1,4 @@
-tosca_definitions_version: cloudify_dsl_1_3
+tosca_definitions_version: cloudify_dsl_1_4
 
 description: >
   This blueprint deploy EC2 for agent tests

--- a/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
+++ b/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 description: >
   This blueprint deploy EC2 for agent tests
 imports:
-  - http://cloudify.co/spec/cloudify/6.3.0/types.yaml # temp old types until we upgrade CI manager
+  - http://cloudify.co/spec/cloudify/6.3.0/types.yaml
   - plugin:cloudify-aws-plugin?version= >=3.0.3
   - plugin:cloudify-utilities-plugin
 

--- a/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
+++ b/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
@@ -1,9 +1,9 @@
-tosca_definitions_version: cloudify_dsl_1_4
+tosca_definitions_version: cloudify_dsl_1_3
 
 description: >
   This blueprint deploy EC2 for agent tests
 imports:
-  - http://cloudify.co/spec/cloudify/7.0.0.dev1/types.yaml
+  - http://cloudify.co/spec/cloudify/6.4.0/types.yaml # temp old types until we upgrade CI manager
   - plugin:cloudify-aws-plugin?version= >=3.0.3
   - plugin:cloudify-utilities-plugin
 

--- a/jenkins/build-pod-windows.yaml
+++ b/jenkins/build-pod-windows.yaml
@@ -4,6 +4,16 @@ spec:
   containers:
   - name: jnlp
     image: jenkins/inbound-agent:windowsservercore-ltsc2019
+    command:
+    - "powershell.exe"
+    args:
+    - "Start-Sleep"
+    - "-s"
+    - "5"
+    - ";"
+    - "powershell.exe"
+    - "-f"
+    - "C:/ProgramData/Jenkins/jenkins-agent.ps1"
   - name: shell
     image: mcr.microsoft.com/powershell:preview-windowsservercore-1809
     command:


### PR DESCRIPTION
A known issue in Jenkins causes windows JNLP containers to take a few seconds to connect.
Adding the args to retry the connection after a few seconds seem to stabilize it.

Also using an older types.yaml in the blueprint to have it working with the 1_3 dsl as the manager+cli used is prior to 6.4.0