### PR TITLE
CI: run tests on 3.10

### DIFF
--- a/cloudify_agent/tests/api/plugins/test_installer.py
+++ b/cloudify_agent/tests/api/plugins/test_installer.py
@@ -1,7 +1,6 @@
 import tempfile
 import logging
 import os
-import platform
 import pytest
 import shutil
 import threading
@@ -18,6 +17,14 @@ from cloudify.utils import setup_logger, target_plugin_prefix, get_python_path
 from cloudify.exceptions import NonRecoverableError
 from cloudify_rest_client.plugins import Plugin
 from cloudify_rest_client.constants import VisibilityState
+
+try:
+    from distro import linux_distribution
+except ImportError:
+    try:
+        from platform import linux_distribution
+    except ImportError:
+        linux_distribution = None
 
 from cloudify_agent.api import exceptions
 from cloudify_agent.api.plugins import installer
@@ -269,8 +276,7 @@ def test_implicit_supported_platform():
 
 @pytest.mark.only_posix
 def test_implicit_dist_and_dist_release():
-    dist, _, dist_release = platform.linux_distribution(
-        full_distribution_name=False)
+    dist, _, dist_release = linux_distribution(full_distribution_name=False)
     dist, dist_release = dist.lower(), dist_release.lower()
     plugins = [
         {'id': '1', 'package_version': '1'},

--- a/cloudify_agent/tests/installer/config/test_configuration.py
+++ b/cloudify_agent/tests/installer/config/test_configuration.py
@@ -96,7 +96,7 @@ def _get_distro_package_url(rest_port=80, manager_host='127.0.0.1'):
     base_url = utils.get_manager_file_server_url(manager_host, rest_port)
     agent_package_url = '{0}/packages/agents'.format(base_url)
     if os.name == 'posix':
-        distro_name = distro.id()
+        distro_name = distro.id().lower()
         distro_codename = distro.codename().lower()
         result['distro'] = distro_name
         result['distro_codename'] = distro_codename

--- a/cloudify_agent/tests/installer/config/test_configuration.py
+++ b/cloudify_agent/tests/installer/config/test_configuration.py
@@ -1,8 +1,8 @@
 from contextlib import contextmanager
 import getpass
 import os
-import platform
 
+import distro
 from mock import patch
 
 from cloudify import constants
@@ -96,11 +96,11 @@ def _get_distro_package_url(rest_port=80, manager_host='127.0.0.1'):
     base_url = utils.get_manager_file_server_url(manager_host, rest_port)
     agent_package_url = '{0}/packages/agents'.format(base_url)
     if os.name == 'posix':
-        distro = platform.dist()[0].lower()
-        distro_codename = platform.dist()[2].lower()
-        result['distro'] = platform.dist()[0].lower()
-        result['distro_codename'] = platform.dist()[2].lower()
-        package = '{0}-{1}-agent.tar.gz'.format(distro, distro_codename)
+        distro_name = distro.id()
+        distro_codename = distro.codename().lower()
+        result['distro'] = distro_name
+        result['distro_codename'] = distro_codename
+        package = '{0}-{1}-agent.tar.gz'.format(distro_name, distro_codename)
     else:
         package = 'cloudify-windows-agent.exe'
     result['package_url'] = '{0}/{1}'.format(agent_package_url, package)

--- a/cloudify_agent/tests/utils.py
+++ b/cloudify_agent/tests/utils.py
@@ -9,7 +9,6 @@ import subprocess
 import wsgiref.simple_server
 from contextlib import contextmanager
 
-# from agent_packager import packager
 import bottle
 import requests
 import wagon

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -106,32 +106,38 @@ pipeline {
                   withVault([configuration: configuration, vaultSecrets: secrets]){
                     sh script:"""
                       ssh -i ~/.ssh/ec2_ssh_key -l centos \$(jq -r '.endpoint.value' capabilities.json) /bin/bash -ex << 'EOT'
+# install & start rabbitmq
 sudo yum install -y epel-release git
 sudo yum install -y rabbitmq-server
-
 sudo systemctl enable rabbitmq-server
 sudo systemctl start rabbitmq-server
 
+# setup python3.10
 curl -fL --retry 5 \
   https://cloudify-cicd.s3.amazonaws.com/python-build-packages/cfy-python3.10.tgz \
   -o cfy-python3.10.tgz
 mkdir python3.10
 tar --strip-components=2 -zxf cfy-python3.10.tgz -C python3.10
 python3.10/bin/python3.10 -m venv venv
+set +x
 . venv/bin/activate
+set -x
 
+# fetch the code
 git clone https://github.com/cloudify-cosmo/cloudify-agent.git \
   --branch "${env.BRANCH_NAME}" \
   --single-branch \
   --depth 1
 
 pushd cloudify-agent
+  # install prereqs
   pip install --upgrade pip setuptools
   pip install -r test-requirements.txt
   pip install -r dev-requirements.txt
   pip install '.[fabric]'
   echo 'run py3.10 tests'
 
+  # run all tests
   pytest \
     --run-rabbit-tests \
     --run-ci-tests \

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
                     sh script:"""
                       ssh -i ~/.ssh/ec2_ssh_key -l centos \$(jq -r '.endpoint.value' capabilities.json) /bin/bash -ex << 'EOT'
 # install & start rabbitmq
-sudo yum install -y epel-release git
+sudo yum install -y epel-release git wget
 sudo yum install -y rabbitmq-server
 sudo systemctl enable rabbitmq-server
 sudo systemctl start rabbitmq-server

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -104,30 +104,43 @@ pipeline {
               container('py310'){
                 dir("${env.WORKSPACE}/${env.PROJECT}/jenkins"){
                   withVault([configuration: configuration, vaultSecrets: secrets]){
-                    sh script:"""#!/bin/bash
-                      ssh -i ~/.ssh/ec2_ssh_key -l centos \$(cat capabilities.json | jq '.endpoint.value' | tr -d '"') /bin/bash << 'EOT'
-set -ex
-sudo yum install -y epel-release git vim python-virtualenv
+                    sh script:"""
+                      ssh -i ~/.ssh/ec2_ssh_key -l centos \$(jq -r '.endpoint.value' capabilities.json) /bin/bash -ex << 'EOT'
+sudo yum install -y epel-release git
 sudo yum install -y rabbitmq-server
-sudo yum install -y wget
-sudo yum install -y python3
-git clone https://github.com/cloudify-cosmo/cloudify-agent.git
+
 sudo systemctl enable rabbitmq-server
 sudo systemctl start rabbitmq-server
-python3 -m venv py3
-source py3/bin/activate
-pip install --upgrade pip setuptools
-export LC_ALL=en_US.utf-8
-export LANG=en_US.utf-8
+
+curl -fL --retry 5 \
+  https://cloudify-cicd.s3.amazonaws.com/python-build-packages/cfy-python3.10.tgz \
+  -o cfy-python3.10.tgz
+mkdir python3.10
+tar --strip-components=2 -zxf cfy-python3.10.tgz -C python3.10
+python3.10/bin/python3.10 -m venv venv
+. venv/bin/activate
+
+git clone https://github.com/cloudify-cosmo/cloudify-agent.git \
+  --branch "${env.BRANCH_NAME}" \
+  --single-branch \
+  --depth 1
+
 pushd cloudify-agent
-git checkout ${env.BRANCH_NAME}
-pip install -r test-requirements.txt
-pip install -r dev-requirements.txt
-pip install '.[fabric]'
-echo 'run py3.10 tests'
-pytest --run-rabbit-tests --run-ci-tests --cov-report term-missing --cov=cloudify_agent cloudify_agent --junitxml=test-results/cloudify_agent_py3.xml
+  pip install --upgrade pip setuptools
+  pip install -r test-requirements.txt
+  pip install -r dev-requirements.txt
+  pip install '.[fabric]'
+  echo 'run py3.10 tests'
+
+  pytest \
+    --run-rabbit-tests \
+    --run-ci-tests \
+    --cov-report term-missing \
+    --cov=cloudify_agent \
+    cloudify_agent \
+    --junitxml=test-results/cloudify_agent_py3.xml
 popd
-deactivate
+
 EOT
                     """, label: 'Prepare instance and run pytests'
                   }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -119,7 +119,7 @@ curl -fL --retry 5 \
 mkdir python3.10
 tar --strip-components=2 -zxf cfy-python3.10.tgz -C python3.10
 python3.10/bin/python3.10 -m venv venv
-set +x
+set +x  # going to activate the venv, hide activate output
 . venv/bin/activate
 set -x
 
@@ -141,8 +141,6 @@ pushd cloudify-agent
   pytest \
     --run-rabbit-tests \
     --run-ci-tests \
-    --cov-report term-missing \
-    --cov=cloudify_agent \
     cloudify_agent \
     --junitxml=test-results/cloudify_agent_py3.xml
 popd

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -135,10 +135,10 @@ pushd cloudify-agent
   pip install -r test-requirements.txt
   pip install -r dev-requirements.txt
   pip install '.[fabric]'
-  echo 'run py3.10 tests'
 
   # run all tests
   pytest \
+    -sv \
     --run-rabbit-tests \
     --run-ci-tests \
     cloudify_agent \

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,17 +1,7 @@
 https://github.com/cloudify-cosmo/cloudify-common/archive/master.zip#egg=cloudify-common[dispatcher]
 mock==1.0.1
 pywinrm==0.4.1
-cryptography>=3.3.2,<3.4
-requests>=2.25.0,<3.0.0
 
-#for python 2.6 support
-xmltodict==0.11.0
-idna==2.7
-
-# for creating the agent package in tests
-https://github.com/cloudify-cosmo/cloudify-agent-packager/archive/master.zip
-pytest==6.2.2; python_version >'3.6'
-pytest==4.6.11; python_version=='2.7'
-coverage==5.4
-pytest-cov==2.11.1
-decorator==4.4.2
+pytest
+coverage
+pytest-cov

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,3 @@ mock==1.0.1
 pywinrm==0.4.1
 
 pytest
-coverage
-pytest-cov


### PR DESCRIPTION
- download our 3.10 build and extract that
- only clone the single branch we need
- better `jq` usage :)
- clean up test-reqs.txt (newer pytest version required for py3.10)