### PR TITLE
RD-6529 Handle distro->architecture field change in 7.0

### DIFF
--- a/cloudify_agent/installer/config/agent_config.py
+++ b/cloudify_agent/installer/config/agent_config.py
@@ -409,6 +409,14 @@ class CloudifyAgentConfig(dict):
         if self.get('architecture'):  # Might be an empty string
             return
 
+        # handle upgrades from pre-7.0
+        if self.get('distro_codename'):
+            if self['distro_codename'].lower() == 'altarch':
+                self['architecture'] = 'aarch64'
+            else:
+                self['architecture'] = 'x86_64'
+            return
+
         if self.is_local:
             self['architecture'] = platform.machine()
         elif self.is_remote:

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -169,7 +169,9 @@ def _copy_values_from_old_agent_config(old_agent, new_agent):
     fields_to_copy = ['windows', 'ip', 'basedir', 'user', 'architecture',
                       'broker_ssl_cert_path', 'agent_rest_cert_path',
                       'network', 'local', 'install_method',
-                      'process_management', 'node_instance_id']
+                      'process_management', 'node_instance_id',
+                      'distro_codename']
+    # distro_codename for supporting upgrade from pre-7.0
     for field in fields_to_copy:
         if field in old_agent:
             new_agent[field] = old_agent[field]


### PR DESCRIPTION
In CM 7.0 we moved to manylinux agents. The distro and distro_codename fields no longer exist, replaced by an architecture field