### PR TITLE
RD-6658 `cfy-agent setup`: update stored agent info

### DIFF
--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -13,14 +13,15 @@
 #  * See the License for the specific language governing permissions and
 #  * limitations under the License.
 
-import uuid
-import json
 import copy
-import tempfile
-import os
 import errno
 import getpass
+import json
+import os
 import pkgutil
+import platform
+import tempfile
+import uuid
 
 import appdirs
 import pkg_resources
@@ -452,6 +453,14 @@ def get_agent_version():
     if version_info['release'] != 'ga':
         version = '{0}-{1}'.format(version, version_info['release'])
     return version
+
+
+def get_system_name():
+    """The current system name, to be stored in the agent info"""
+    if os.name == 'nt':
+        return 'windows'
+    # platform.machine() is x86_64, or aarch64, or...
+    return f'linux {platform.machine()}'
 
 
 def get_windows_basedir():

--- a/cloudify_agent/shell/main.py
+++ b/cloudify_agent/shell/main.py
@@ -22,6 +22,7 @@ from cloudify.utils import setup_logger
 
 from cloudify_agent.api.utils import (
     get_agent_version,
+    get_system_name,
     logger as api_utils_logger,
     get_rest_client,
 )
@@ -186,6 +187,12 @@ def setup(
         executable_temp_path=agent_config.get('executable_temp_path'),
     )
     _save_daemon(daemon)
+
+    version = get_agent_version()
+    system = get_system_name()
+    click.echo(f'Agent version: {version}, system: {system}')
+    client.agents.update(name, version=version, system=system)
+
     click.echo(f'Successfully created daemon: {daemon.name}')
 
 


### PR DESCRIPTION
When setting up the agent, not only fetch the agent info, but also update it with the settings we've found on the current machine.

For now, this is only the agent version, and the name of the OS.