### PR TITLE
RD-7028 agent install: store broker_conf in `cfy-agent setup`

### DIFF
--- a/cloudify_agent/api/pm/base.py
+++ b/cloudify_agent/api/pm/base.py
@@ -391,7 +391,6 @@ class Daemon(object):
         """
         self.create_script()
         self.create_config()
-        self.create_broker_conf()
 
     def start(self,
               interval=defaults.START_INTERVAL,

--- a/cloudify_agent/shell/main.py
+++ b/cloudify_agent/shell/main.py
@@ -193,6 +193,7 @@ def setup(
         executable_temp_path=agent_config.get('executable_temp_path'),
     )
     _save_daemon(daemon)
+    daemon.create_broker_conf()
 
     version = get_agent_version()
     system = get_system_name()


### PR DESCRIPTION
It needs to be stored when we're running as the agent user. It was called in configure, which is called as root, which lead to the conf file being owned by root.