### PR TITLE
RD-7005 Put the resources/ dir under agent dir

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   TOX_ENV: pywin
 
-  erlang_download_url: http://erlang.org/download/otp_win64_21.3.exe
+  erlang_download_url: https://github.com/erlang/otp/releases/download/OTP-21.3/otp_win64_21.3.exe
   erlang_installer_path: C:\Users\appveyor\erlang_install.exe
   rabbitmq_download_url: https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.4/rabbitmq-server-3.8.4.exe
   rabbitmq_installer_path: C:\Users\appveyor\rabbitmq_install.exe

--- a/cloudify_agent/shell/main.py
+++ b/cloudify_agent/shell/main.py
@@ -191,6 +191,7 @@ def setup(
         min_workers=agent_config.get('min_workers'),
         max_workers=agent_config.get('max_workers'),
         executable_temp_path=agent_config.get('executable_temp_path'),
+        resources_root=os.path.join(agent_dir, 'resources'),
     )
     _save_daemon(daemon)
     daemon.create_broker_conf()

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -212,7 +212,7 @@ EOT
           }
           environment {
             TOX_ENV = 'pywin'
-            ERLANG_DOWNLOAD_URL = 'http://erlang.org/download/otp_win64_21.3.exe'
+            ERLANG_DOWNLOAD_URL = 'https://github.com/erlang/otp/releases/download/OTP-21.3/otp_win64_21.3.exe'
             ERLANG_INSTALLER_PATH = 'C:\\erlang_install.exe'
             RABBITMQ_DOWNLOAD_URL = 'https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.8.4/rabbitmq-server-3.8.4.exe'
             RABBITMQ_INSTALLER_PATH = 'C:\\rabbitmq_install.exe'

--- a/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
+++ b/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 description: >
   This blueprint deploy EC2 for agent tests
 imports:
-  - http://cloudify.co/spec/cloudify/7.1.0.dev1/types.yaml
+  - http://cloudify.co/spec/cloudify/6.3.0/types.yaml
   - plugin:cloudify-aws-plugin?version= >=3.0.3
   - plugin:cloudify-utilities-plugin
 


### PR DESCRIPTION
Using a global location (/tmp/resources) by default a bad idea because:
- it'll be accessible by other agents
- the agent user doesn't necessarily have write permissions there