### PR TITLE
RD-7005 Put the resources/ dir under agent dir

### DIFF
--- a/cloudify_agent/shell/main.py
+++ b/cloudify_agent/shell/main.py
@@ -191,6 +191,7 @@ def setup(
         min_workers=agent_config.get('min_workers'),
         max_workers=agent_config.get('max_workers'),
         executable_temp_path=agent_config.get('executable_temp_path'),
+        resources_root=os.path.join(agent_dir, 'resources'),
     )
     _save_daemon(daemon)
     daemon.create_broker_conf()


### PR DESCRIPTION
Using a global location (/tmp/resources) by default a bad idea because:
- it'll be accessible by other agents
- the agent user doesn't necessarily have write permissions there