### PR TITLE
RD-7005 windows.ps1: create daemon when setting up agent

### DIFF
--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -75,6 +75,8 @@ function SetupAgent()
         --rest-token "{{ auth_token_value }}" `
         --agent-dir "{{ conf.basedir }}\{{ conf.name }}" `
         --process-management "nssm"
+
+    run "{{ conf.basedir }}\Scripts\cfy-agent.exe" {{ debug_flag }} daemons create --name "{{ conf.name }}"
 }
 
 
@@ -83,7 +85,7 @@ function StartAgent()
 {
     if (-Not (run "{{ conf.basedir }}\Scripts\cfy-agent.exe" daemons list | Select-String {{ conf.name }})) {
         Write-Host "Creating daemon..."
-        run "{{ conf.basedir }}\Scripts\cfy-agent.exe" {{ debug_flag }} daemons create --name "{{ conf.name }}"
+        SetupAgent
         Write-Host "Daemon created successfully"
     } else {
         Write-Host "Agent already created, skipping create agent."


### PR DESCRIPTION
I'm not sure why StartAgent has this "check if already exists", because linux doesn't have it.
Anyway, let's still have it.

So `daemons list` shows the daemon to exist, if `cfy-agent setup` has been called. Therefore, we must run `daemons create` right next to `setup`. Otherwise, we end up calling `setup`, but never actually `daemons create`.