### PR TITLE
RD-7005 Agent upgrade directory fixups

### DIFF
--- a/cloudify_agent/api/utils.py
+++ b/cloudify_agent/api/utils.py
@@ -468,11 +468,11 @@ def get_windows_basedir():
     # is not really supported. They do then give details of how to do so, but
     # as it's stated as not supported by MS, we won't support it.
     # https://support.microsoft.com/en-us/help/933700/microsoft-does-not-support-changing-the-location-of-the-program-files  # noqa
-    return 'C:\\Program Files\\Cloudify {} Agents'.format(get_agent_version())
+    return 'C:\\Program Files\\Cloudify Agents'
 
 
 def get_linux_basedir():
-    return '/opt/cloudify-agent-{0}'.format(get_agent_version())
+    return '/opt/cloudify-agent'
 
 
 def get_agent_basedir(is_windows=False):

--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -97,9 +97,6 @@ class AgentInstaller(object):
             flags = '--fix-shebangs'
         return flags
 
-    def create_custom_env_file_on_target(self, environment):
-        raise NotImplementedError('Must be implemented by sub-class')
-
     @property
     def runner(self):
         raise NotImplementedError('Must be implemented by sub-class')
@@ -137,20 +134,3 @@ class LocalInstallerMixin(AgentInstaller):
     def delete_agent(self):
         self.run_daemon_command('delete')
         shutil.rmtree(self.cloudify_agent['agent_dir'])
-
-    def create_custom_env_file_on_target(self, environment):
-        posix = not self.cloudify_agent.is_windows
-        self.logger.debug('Creating a environment file from {0}'
-                          .format(environment))
-        return utils.env_to_file(env_variables=environment, posix=posix)
-
-
-class RemoteInstallerMixin(AgentInstaller):
-
-    def create_custom_env_file_on_target(self, environment):
-        posix = not self.cloudify_agent.is_windows
-        env_file = utils.env_to_file(env_variables=environment, posix=posix)
-        if env_file:
-            return self.runner.put_file(src=env_file)
-        else:
-            return None

--- a/cloudify_agent/installer/linux.py
+++ b/cloudify_agent/installer/linux.py
@@ -15,10 +15,9 @@
 
 from cloudify_agent.installer import LinuxInstallerMixin
 from cloudify_agent.installer import LocalInstallerMixin
-from cloudify_agent.installer import RemoteInstallerMixin
 
 
-class RemoteLinuxAgentInstaller(LinuxInstallerMixin, RemoteInstallerMixin):
+class RemoteLinuxAgentInstaller(LinuxInstallerMixin):
 
     def __init__(self, cloudify_agent, runner, logger=None):
         super(RemoteLinuxAgentInstaller, self).__init__(cloudify_agent, logger)

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -36,27 +36,17 @@ LOCAL_CLEANUP_PATHS_KEY = 'local_cleanup_paths'
 class AgentInstallationScriptBuilder(AgentInstaller):
     def __init__(self, cloudify_agent):
         super(AgentInstallationScriptBuilder, self).__init__(cloudify_agent)
-        self.custom_env = None
         self.file_server_root = cloudify_utils.get_manager_file_server_root()
         self.file_server_url = cloudify_agent['file_server_url']
 
-        basedir = self.cloudify_agent['basedir']
         if cloudify_agent.is_windows:
             self.install_script_template = 'script/windows.ps1.template'
             self.install_script_filename = '{0}.ps1'.format(uuid.uuid4())
-            self.custom_env_path = '{0}\\custom_agent_env.bat'.format(basedir)
         else:
             self.install_script_template = 'script/linux.sh.template'
             self.install_script_filename = '{0}.sh'.format(uuid.uuid4())
-            self.custom_env_path = '{0}/custom_agent_env.sh'.format(basedir)
         self.stop_old_agent_template = 'script/stop-agent.py.template'
         self.stop_old_agent_filename = '{0}.py'.format(uuid.uuid4())
-
-    def create_custom_env_file_on_target(self, environment):
-        if not environment:
-            return
-        self.custom_env = environment
-        return self.custom_env_path
 
     @staticmethod
     def _get_template(template_filename):

--- a/cloudify_agent/installer/windows.py
+++ b/cloudify_agent/installer/windows.py
@@ -15,10 +15,9 @@
 
 from cloudify_agent.installer import WindowsInstallerMixin
 from cloudify_agent.installer import LocalInstallerMixin
-from cloudify_agent.installer import RemoteInstallerMixin
 
 
-class RemoteWindowsAgentInstaller(WindowsInstallerMixin, RemoteInstallerMixin):
+class RemoteWindowsAgentInstaller(WindowsInstallerMixin):
 
     def __init__(self, cloudify_agent, runner, logger=None):
         super(RemoteWindowsAgentInstaller, self).__init__(cloudify_agent,

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -169,15 +169,16 @@ def _copy_values_from_old_agent_config(old_agent, new_agent):
     fields_to_copy = ['windows', 'ip', 'basedir', 'user', 'architecture',
                       'broker_ssl_cert_path', 'network', 'local',
                       'install_method', 'process_management',
-                      'node_instance_id', 'distro_codename']
+                      'node_instance_id', 'distro_codename', 'basedir']
     # distro_codename for supporting upgrade from pre-7.0
     for field in fields_to_copy:
         if field in old_agent:
             new_agent[field] = old_agent[field]
-    if new_agent['windows']:
-        new_agent['basedir'] = utils.get_windows_basedir()
-    else:
-        new_agent['basedir'] = utils.get_linux_basedir()
+    if not new_agent.get('basedir'):
+        if new_agent['windows']:
+            new_agent['basedir'] = utils.get_windows_basedir()
+        else:
+            new_agent['basedir'] = utils.get_linux_basedir()
 
 
 def create_new_agent_config(old_agent):

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -169,16 +169,11 @@ def _copy_values_from_old_agent_config(old_agent, new_agent):
     fields_to_copy = ['windows', 'ip', 'basedir', 'user', 'architecture',
                       'broker_ssl_cert_path', 'network', 'local',
                       'install_method', 'process_management',
-                      'node_instance_id', 'distro_codename', 'basedir']
+                      'node_instance_id', 'distro_codename']
     # distro_codename for supporting upgrade from pre-7.0
     for field in fields_to_copy:
         if field in old_agent:
             new_agent[field] = old_agent[field]
-    if not new_agent.get('basedir'):
-        if new_agent['windows']:
-            new_agent['basedir'] = utils.get_windows_basedir()
-        else:
-            new_agent['basedir'] = utils.get_linux_basedir()
 
 
 def create_new_agent_config(old_agent):

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -250,6 +250,7 @@ main()
     fi
 
     if [ "${DO_INSTALL}" ]; then
+        log "Installing to ${BASE_DIR}"
         download "$(package_url)" | {
             if [ "${PROCESS_MANAGEMENT}" = "detach" ]; then
                 tar -xzf - --strip=1 -C "${BASE_DIR}"

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -15,6 +15,7 @@ BASE_DIR="{{ conf.basedir }}"
 AGENT_DIR="{{ conf.agent_dir }}"
 AGENT_USER="{{ conf.user }}"
 AGENT_NAME="{{ conf.name }}"
+INSTANCE_ID="{{ conf.node_instance_id }}"
 REST_CERT="{{ conf.rest_ssl_cert }}"
 AUTH_TOKEN_VALUE="{{ auth_token_value }}"
 PACKAGE_URL="{{ conf.package_url }}"
@@ -262,6 +263,7 @@ main()
 
     setup_args=(
         --name "${AGENT_NAME}"
+        --node-instance-id "${INSTANCE_ID}"
         --rest-hosts "${REST_HOST}"
         --rest-port "${REST_PORT}"
         --rest-ca-path "${AGENT_DIR}/cloudify/ssl/cloudify_internal_cert.pem"

--- a/cloudify_agent/resources/script/linux.sh.template
+++ b/cloudify_agent/resources/script/linux.sh.template
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script downloads, installs, and starts a Cloudify Agent.
-# The agent is installed into {{ conf.basedir }}, then a service is
+# The agent is installed into {{ conf.install_dir }}, then a service is
 # created using the configured process management system, and started.
 
 # no `set -x` for this script, because we could display some values that
@@ -11,7 +11,7 @@ set -euo pipefail
 # Set all variables up front, using templating (templating is never used
 # in this script afterwards)
 PROCESS_MANAGEMENT="{{ conf.process_management.name }}"
-BASE_DIR="{{ conf.basedir }}"
+INSTALL_DIR="{{ conf.install_dir }}"
 AGENT_DIR="{{ conf.agent_dir }}"
 AGENT_USER="{{ conf.user }}"
 AGENT_NAME="{{ conf.name }}"
@@ -71,7 +71,7 @@ log()
 #   i.e. installing the agent package into a system-wide location (like /opt),
 #   and creating a daemon service
 # - with process_management=detach, in which case we just run everything
-#   directly, and never sudo. BASE_DIR had better already be writable by the
+#   directly, and never sudo. INSTALL_DIR had better already be writable by the
 #   running user
 run_as_user()
 {
@@ -114,12 +114,12 @@ prepare_installation()
     log "Adding the user ${AGENT_USER} to the cfyagent group"
     run_as_root usermod -a -G cfyagent "${AGENT_USER}"
 
-    if [ -d "${BASE_DIR}" ]; then
-        log "Not creating ${BASE_DIR} - already exists"
+    if [ -d "${INSTALL_DIR}" ]; then
+        log "Not creating ${INSTALL_DIR} - already exists"
         return
     fi
-    log "Creating ${BASE_DIR}"
-    run_as_root install -g cfyagent -m ug+rX -d "${BASE_DIR}"
+    log "Creating ${INSTALL_DIR}"
+    run_as_root install -g cfyagent -m ug+rX -d "${INSTALL_DIR}"
 }
 
 
@@ -223,14 +223,14 @@ start_daemon()
     log "Process management system: ${PROCESS_MANAGEMENT}"
     if [ "${PROCESS_MANAGEMENT}" = "detach" ]; then
         log "Creating the daemon (as ${AGENT_USER})"
-        run_as_user "${BASE_DIR}/env/bin/cfy-agent" "${create_args[@]}"
+        run_as_user "${INSTALL_DIR}/env/bin/cfy-agent" "${create_args[@]}"
         log "Starting the daemon (as ${AGENT_USER})"
-        run_as_user "${BASE_DIR}/env/bin/cfy-agent" "${start_args[@]}"
+        run_as_user "${INSTALL_DIR}/env/bin/cfy-agent" "${start_args[@]}"
     else
         log "Creating the daemon (as root)"
-        run_as_root "${BASE_DIR}/env/bin/cfy-agent" "${create_args[@]}"
+        run_as_root "${INSTALL_DIR}/env/bin/cfy-agent" "${create_args[@]}"
         log "Creating the daemon (as root)"
-        run_as_root "${BASE_DIR}/env/bin/cfy-agent" "${start_args[@]}"
+        run_as_root "${INSTALL_DIR}/env/bin/cfy-agent" "${start_args[@]}"
     fi
 }
 
@@ -250,16 +250,16 @@ main()
     fi
 
     if [ "${DO_INSTALL}" ]; then
-        log "Installing to ${BASE_DIR}"
+        log "Installing to ${INSTALL_DIR}"
         download "$(package_url)" | {
             if [ "${PROCESS_MANAGEMENT}" = "detach" ]; then
-                tar -xzf - --strip=1 -C "${BASE_DIR}"
+                tar -xzf - --strip=1 -C "${INSTALL_DIR}"
             else
-                run_as_root tar --group=cfyagent -xzf - --strip=1 -C "${BASE_DIR}"
+                run_as_root tar --group=cfyagent -xzf - --strip=1 -C "${INSTALL_DIR}"
             fi
         }
         log "Fixing agent package shebangs"
-        run_as_root "${BASE_DIR}/env/bin/python" "${BASE_DIR}/env/bin/cfy-agent" configure --fix-shebangs
+        run_as_root "${INSTALL_DIR}/env/bin/python" "${INSTALL_DIR}/env/bin/cfy-agent" configure --fix-shebangs
     fi
 
     setup_args=(
@@ -279,11 +279,11 @@ main()
 
     log "Preparing the agent"
     log "Manager address: ${REST_HOST};  port: ${REST_PORT}"
-    run_as_user "${BASE_DIR}/env/bin/cfy-agent" setup "${setup_args[@]}"
+    run_as_user "${INSTALL_DIR}/env/bin/cfy-agent" setup "${setup_args[@]}"
 
     # inspect so that the user can reference agent settings in the logfile
     # (inspect hides "secret" settings)
-    run_as_user "${BASE_DIR}/env/bin/cfy-agent" daemons inspect --name "${AGENT_NAME}"
+    run_as_user "${INSTALL_DIR}/env/bin/cfy-agent" daemons inspect --name "${AGENT_NAME}"
 
     if [ "${DO_START}" ]; then
         start_daemon

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -68,6 +68,7 @@ function SetupAgent()
 {
     run "{{ conf.basedir }}\Scripts\cfy-agent.exe" setup `
         --name "{{ conf.name }}" `
+        --node-instance-id "{{ conf.node_instance_id }}"
         --rest-hosts "{{ conf.rest_host | join(',') }}" `
         --rest-port "{{ conf.rest_port }}" `
         --rest-ca-path "{{ conf.basedir }}\{{ conf.name }}\cloudify\ssl\cloudify_internal_cert.pem" `

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -12,13 +12,13 @@ $ErrorActionPreference = "Stop"
 function AddSSLCert()
 {
     # Make sure the cert directory exists
-    New-Item -ItemType directory -Force -Path "{{ conf.basedir }}\{{ conf.name }}\cloudify\ssl"
+    New-Item -ItemType directory -Force -Path "{{ conf.install_dir }}\{{ conf.name }}\cloudify\ssl"
 
     # Create a new file with the certificate content
-    New-Item "{{ conf.basedir }}\{{ conf.name }}\cloudify\ssl\cloudify_internal_cert.pem" -type file -force -value "{{ conf.rest_ssl_cert }}"
+    New-Item "{{ conf.install_dir }}\{{ conf.name }}\cloudify\ssl\cloudify_internal_cert.pem" -type file -force -value "{{ conf.rest_ssl_cert }}"
 
     # Add the certificate to the root cert store
-    Import-Certificate -FilePath "{{ conf.basedir }}\{{ conf.name }}\cloudify\ssl\cloudify_internal_cert.pem" -CertStoreLocation Cert:\LocalMachine\Root
+    Import-Certificate -FilePath "{{ conf.install_dir }}\{{ conf.name }}\cloudify\ssl\cloudify_internal_cert.pem" -CertStoreLocation Cert:\LocalMachine\Root
 }
 {% endif %}
 
@@ -46,18 +46,18 @@ function Download($Url, $OutputPath)
 
 function InstallAgent()
 {
-    if (-Not (Test-Path "{{ conf.basedir }}\Scripts")) {
+    if (-Not (Test-Path "{{ conf.install_dir }}\Scripts")) {
         Write-Host "Installing cloudify agent package"
         {% if conf.package_url %}
-        Download "{{ conf.package_url }}" "{{ conf.basedir }}\cloudify-windows-agent-package.exe"
+        Download "{{ conf.package_url }}" "{{ conf.install_dir }}\cloudify-windows-agent-package.exe"
         {% else %}
-        Download "{{ conf.file_server_url }}/packages/agents/cloudify-windows-agent.exe" "{{ conf.basedir }}\cloudify-windows-agent-package.exe"
+        Download "{{ conf.file_server_url }}/packages/agents/cloudify-windows-agent.exe" "{{ conf.install_dir }}\cloudify-windows-agent-package.exe"
         {% endif %}
         # This call is not blocking so we pipe the output to null to make it blocking
         # There's no point trying to pipe it to not null because in the event it has problems it will
         # make a dialog box despite all the flags telling it we really want it to not do stuff like that.
-        Write-Host 'Starting install using "{{ conf.basedir }}\cloudify-windows-agent-package.exe"'
-        & "{{ conf.basedir }}\cloudify-windows-agent-package.exe" /SILENT /VERYSILENT /SUPPRESSMSGBOXES | Out-Null
+        Write-Host 'Starting install using "{{ conf.install_dir }}\cloudify-windows-agent-package.exe"'
+        & "{{ conf.install_dir }}\cloudify-windows-agent-package.exe" /SILENT /VERYSILENT /SUPPRESSMSGBOXES | Out-Null
     } else {
         Write-Host "Agent package already installed"
     }
@@ -66,25 +66,25 @@ function InstallAgent()
 
 function SetupAgent()
 {
-    run "{{ conf.basedir }}\Scripts\cfy-agent.exe" setup `
+    run "{{ conf.install_dir }}\Scripts\cfy-agent.exe" setup `
         --name "{{ conf.name }}" `
         --node-instance-id "{{ conf.node_instance_id }}"
         --rest-hosts "{{ conf.rest_host | join(',') }}" `
         --rest-port "{{ conf.rest_port }}" `
-        --rest-ca-path "{{ conf.basedir }}\{{ conf.name }}\cloudify\ssl\cloudify_internal_cert.pem" `
+        --rest-ca-path "{{ conf.install_dir }}\{{ conf.name }}\cloudify\ssl\cloudify_internal_cert.pem" `
         --tenant-name "{{ tenant_name }}" `
         --rest-token "{{ auth_token_value }}" `
-        --agent-dir "{{ conf.basedir }}\{{ conf.name }}" `
+        --agent-dir "{{ conf.install_dir }}\{{ conf.name }}" `
         --process-management "nssm"
 
-    run "{{ conf.basedir }}\Scripts\cfy-agent.exe" {{ debug_flag }} daemons create --name "{{ conf.name }}"
+    run "{{ conf.install_dir }}\Scripts\cfy-agent.exe" {{ debug_flag }} daemons create --name "{{ conf.name }}"
 }
 
 
 {% if start %}
 function StartAgent()
 {
-    if (-Not (run "{{ conf.basedir }}\Scripts\cfy-agent.exe" daemons list | Select-String {{ conf.name }})) {
+    if (-Not (run "{{ conf.install_dir }}\Scripts\cfy-agent.exe" daemons list | Select-String {{ conf.name }})) {
         Write-Host "Creating daemon..."
         SetupAgent
         Write-Host "Daemon created successfully"
@@ -93,7 +93,7 @@ function StartAgent()
     }
 
     Write-Host "Starting daemon..."
-    run "{{ conf.basedir }}\Scripts\cfy-agent.exe" {{ debug_flag }} daemons start --name "{{ conf.name }}"
+    run "{{ conf.install_dir }}\Scripts\cfy-agent.exe" {{ debug_flag }} daemons start --name "{{ conf.name }}"
     Write-Host "Daemon started successfully"
 }
 {% endif %}

--- a/cloudify_agent/shell/main.py
+++ b/cloudify_agent/shell/main.py
@@ -83,6 +83,10 @@ def _parse_rest_hosts(ctx, param, value):
     help='The name of the agent',
 )
 @click.option(
+    '--node-instance-id',
+    help='ID of the current node instance (defaults to agent name)',
+)
+@click.option(
     '--rest-hosts',
     help='Comma-separated list of Cloudify Manager REST-service addresses',
     callback=_parse_rest_hosts,
@@ -127,8 +131,11 @@ def setup(
     agent_dir,
     process_management,
     bypass_maintenance=False,
+    node_instance_id=None,
 ):
     """Prepare the agent, storing the agent settings"""
+    if node_instance_id is None:
+        node_instance_id = name
     client = get_rest_client(
         rest_host=rest_hosts,
         rest_port=rest_port,
@@ -137,8 +144,10 @@ def setup(
         ssl_cert_path=rest_ca_path,
         bypass_maintenance_mode=bypass_maintenance,
     )
-
-    inst = client.node_instances.get(name, evaluate_functions=True)
+    inst = client.node_instances.get(
+        node_instance_id,
+        evaluate_functions=True,
+    )
     agent = client.agents.get(name)
     agent_config = inst.runtime_properties['cloudify_agent']
     agent_config['agent_dir'] = agent_dir

--- a/cloudify_agent/tests/installer/config/test_configuration.py
+++ b/cloudify_agent/tests/installer/config/test_configuration.py
@@ -103,14 +103,17 @@ def _test_prepare(agent_ssl_cert, agent_config, expected_values,
                   context=None):
     user = getpass.getuser()
     is_windows = os.name == 'nt'
+    version = utils.get_agent_version()
     basedir = utils.get_agent_basedir(is_windows)
-    envdir = os.path.join(basedir, 'env')
+    install_dir = os.path.join(basedir, f'agent-{version}')
+    envdir = os.path.join(install_dir, 'env')
 
     # This test needs to be adapted to security settings
     expected = {
         'process_management': {},
-        'basedir': basedir,
+        'basedir': None,
         'name': 'test_node',
+        'install_dir': install_dir,
         'rest_host': ['127.0.0.1'],
         'heartbeat': None,
         'queue': 'test_node',
@@ -129,7 +132,7 @@ def _test_prepare(agent_ssl_cert, agent_config, expected_values,
         'system_python': 'python',
         'bypass_maintenance': False,
         'network': 'default',
-        'version': utils.get_agent_version(),
+        'version': version,
         'node_instance_id': 'test_node',
         'log_level': 'info',
         'log_max_bytes': 5242880,

--- a/cloudify_agent/tests/test_operations.py
+++ b/cloudify_agent/tests/test_operations.py
@@ -25,7 +25,7 @@ def test_create_agent_dict(agent_ssl_cert, tmp_path):
         for k in equal_keys:
             assert old_agent[k] == new_agent[k]
             assert old_agent[k] == third_agent[k]
-        nonequal_keys = ['envdir', 'name', 'rest_host', 'basedir']
+        nonequal_keys = ['name', 'rest_host']
         for k in nonequal_keys:
             assert old_agent[k] != new_agent[k]
             assert old_agent[k] != third_agent[k]


### PR DESCRIPTION
- keep the configured basedir, don't revert to the default
- separately pass in node-instance-id, which only defaults to the name