### PR TITLE
RND-262 Upgrade operation: put rest_port in the context

### DIFF
--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -283,7 +283,8 @@ def _get_cloudify_context(agent, task_name, new_agent_connection=None):
         'execution_id': ctx.execution_id,
         'tenant': ctx.tenant,
         'rest_token': get_rest_token(),
-        'rest_host': agent['rest_host']
+        'rest_host': ctx.rest_host,
+        'rest_port': ctx.rest_port,
     }
 
     if new_agent_connection:

--- a/cloudify_agent/resources/script/windows.ps1.template
+++ b/cloudify_agent/resources/script/windows.ps1.template
@@ -68,7 +68,7 @@ function SetupAgent()
 {
     run "{{ conf.install_dir }}\Scripts\cfy-agent.exe" setup `
         --name "{{ conf.name }}" `
-        --node-instance-id "{{ conf.node_instance_id }}"
+        --node-instance-id "{{ conf.node_instance_id }}" `
         --rest-hosts "{{ conf.rest_host | join(',') }}" `
         --rest-port "{{ conf.rest_port }}" `
         --rest-ca-path "{{ conf.install_dir }}\{{ conf.name }}\cloudify\ssl\cloudify_internal_cert.pem" `


### PR DESCRIPTION
This operation renders the operation context in-line so that it can be sent to the old agent's rabbitmq;  we better include the rest port in it too, like all other operations do. Otherwise, the remote agent tries to look up the port in envvars, and that might be missing (will be missing, for new agents).

Also, use rest_host from our current ctx. It always must be the current manager, and anyway - we include the rest_token for the current manager.