### PR TITLE
RD-7005 windows agent builder: use consistent path

### DIFF
--- a/packaging/windows/win_agent_builder.ps1
+++ b/packaging/windows/win_agent_builder.ps1
@@ -12,9 +12,9 @@ $ErrorActionPreference="stop"
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 $DISPLAY_NAME = $VERSION + '-' + $PRERELEASE
-$AGENT_PATH = "C:\Program Files\Cloudify $DISPLAY_NAME Agents"
+$AGENT_PATH = "C:\Program Files\Cloudify Agents\agent-$DISPLAY_NAME"
 if ( $PRERELEASE -eq "ga" ) {
-   $AGENT_PATH = "C:\Program Files\Cloudify $VERSION Agents"
+   $AGENT_PATH = "C:\Program Files\Cloudify Agents\agent-$VERSION"
    $DISPLAY_NAME = $VERSION
 }
 $GET_PIP_URL = "http://repository.cloudifysource.org/cloudify/components/win-cli-package-resources/get-pip-23.py"


### PR DESCRIPTION
Same as utils.py/get_windows_basedir, after that was changed