### PR TITLE
RND-293 Fixup windows cfy-agent path

### DIFF
--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -21,7 +21,7 @@ from cloudify_agent.installer.runners.local_runner import LocalCommandRunner
 from cloudify.utils import setup_logger
 
 from cloudify_agent.shell import env
-from cloudify_agent.api import utils, defaults
+from cloudify_agent.api import defaults
 
 
 class AgentInstaller(object):
@@ -110,11 +110,12 @@ class WindowsInstallerMixin(AgentInstaller):
 
     @property
     def cfy_agent_path(self):
-        version = utils.get_agent_version()
-        return (
-            '"C:\\Program Files\\'
-            'Cloudify {} Agents\\Scripts\\cfy-agent"'.format(version)
+        script_path = ntpath.join(
+            self.cloudify_agent['install_dir'],
+            'Scripts',
+            "cfy-agent.exe",
         )
+        return f'"{script_path}"'
 
 
 class LinuxInstallerMixin(AgentInstaller):

--- a/cloudify_agent/installer/runners/winrm_runner.py
+++ b/cloudify_agent/installer/runners/winrm_runner.py
@@ -24,7 +24,7 @@ from cloudify.exceptions import CommandExecutionError
 from cloudify.utils import CommandExecutionResponse
 from cloudify.utils import setup_logger
 
-from cloudify_agent.installer import utils
+from cloudify_agent.api import utils
 
 from cloudify_rest_client.utils import is_kerberos_env
 from functools import reduce

--- a/cloudify_agent/tests/installer/test_utils.py
+++ b/cloudify_agent/tests/installer/test_utils.py
@@ -1,4 +1,4 @@
-from cloudify_agent.installer import utils
+from cloudify_agent.api import utils
 
 
 def test_env_to_file():


### PR DESCRIPTION
This ports #892 to 7.0.0

* RND-293 Fixup windows cfy-agent path

This now mirrors the actual install_dir

* fix the imports

the utils were re-imported, let's just import from the actual source instead