### PR TITLE
RND-386 Remove unused BROKER_SSL_CERT_PATH envvar

### DIFF
--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -14,14 +14,10 @@
 #  * limitations under the License.
 
 import ntpath
-import os
 import shutil
 
 from cloudify_agent.installer.runners.local_runner import LocalCommandRunner
 from cloudify.utils import setup_logger
-
-from cloudify_agent.shell import env
-from cloudify_agent.api import defaults
 
 
 class AgentInstaller(object):

--- a/cloudify_agent/installer/__init__.py
+++ b/cloudify_agent/installer/__init__.py
@@ -51,30 +51,6 @@ class AgentInstaller(object):
             .format(command, self.cloudify_agent['name']),
             execution_env=execution_env)
 
-    def _get_local_ssl_cert_paths(self):
-        if self.cloudify_agent.get('ssl_cert_path'):
-            return [self.cloudify_agent['ssl_cert_path']]
-        else:
-            return [
-                os.environ[env.CLOUDIFY_LOCAL_REST_CERT_PATH],
-                os.environ[env.CLOUDIFY_BROKER_SSL_CERT_PATH],
-            ]
-
-    def _get_remote_ssl_cert_path(self):
-        agent_dir = os.path.expanduser(self.cloudify_agent['agent_dir'])
-        cert_filename = defaults.AGENT_SSL_CERT_FILENAME
-        if self.cloudify_agent.is_windows:
-            path_join = ntpath.join
-            ssl_target_dir = defaults.SSL_CERTS_TARGET_DIR.replace('/', '\\')
-        else:
-            path_join = os.path.join
-            ssl_target_dir = defaults.SSL_CERTS_TARGET_DIR
-
-        path = path_join(agent_dir, ssl_target_dir, cert_filename)
-        self.cloudify_agent['agent_rest_cert_path'] = path
-        self.cloudify_agent['broker_ssl_cert_path'] = path
-        return path
-
     def configure_agent(self):
         self.run_daemon_command('configure')
 

--- a/cloudify_agent/installer/config/agent_config.py
+++ b/cloudify_agent/installer/config/agent_config.py
@@ -337,10 +337,6 @@ class CloudifyAgentConfig(dict):
         if not self.get('envdir'):
             self['envdir'] = join(self['install_dir'], 'env')
 
-        if not self.get('broker_ssl_cert_path'):
-            self['broker_ssl_cert_path'] = \
-                cloudify_utils.get_broker_ssl_cert_path()
-
 
 def _get_agent_inputs(params):
     """Return the agent config inputs received in the invocation"""

--- a/cloudify_agent/tests/installer/config/test_configuration.py
+++ b/cloudify_agent/tests/installer/config/test_configuration.py
@@ -4,7 +4,6 @@ import os
 
 from mock import patch
 
-from cloudify import constants
 from cloudify_agent.api import utils
 from cloudify_agent.installer.config.agent_config import CloudifyAgentConfig
 from cloudify_agent.tests.installer.config import mock_context
@@ -127,7 +126,6 @@ def _test_prepare(agent_ssl_cert, agent_config, expected_values,
         'file_server_url': 'https://127.0.0.1:80/resources',
         'max_workers': 5,
         'min_workers': 0,
-        'broker_ssl_cert_path': os.environ[constants.BROKER_SSL_CERT_PATH],
         'windows': is_windows,
         'system_python': 'python',
         'bypass_maintenance': False,


### PR DESCRIPTION
This isn't used anymore, because shell.py/main, just downloads the cert using the restclient