### PR TITLE
RND-389 Agent install scripts: use the fileserver

### DIFF
--- a/cloudify_agent/installer/operations.py
+++ b/cloudify_agent/installer/operations.py
@@ -55,7 +55,7 @@ def create(cloudify_agent, installer, **_):
         ctx.logger.info('Working in "proxied" mode')
     elif cloudify_agent.is_provided:
         ctx.logger.info('Working in "provided" mode')
-        _, install_script_download_link = script.install_script_download_link(
+        install_script_download_link = script.install_script_download_link(
             cloudify_agent
         )
         ctx.logger.info(

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -15,13 +15,12 @@
 
 from contextlib import contextmanager
 import os
-from posixpath import join as url_join
 import tempfile
 import uuid
 
 import jinja2
 
-from cloudify import ctx, utils as cloudify_utils
+from cloudify import ctx
 from cloudify.constants import CLOUDIFY_TOKEN_AUTHENTICATION_HEADER
 
 from cloudify_agent.api import utils

--- a/cloudify_agent/installer/script.py
+++ b/cloudify_agent/installer/script.py
@@ -79,9 +79,9 @@ class AgentInstallationScriptBuilder(AgentInstaller):
         """
         script_filename = self.install_script_filename
         script_content = self.install_script(add_ssl_cert=add_ssl_cert)
-        return self._get_script_path_and_url(script_filename, script_content)
+        return self._get_script_url(script_filename, script_content)
 
-    def _get_script_path_and_url(self, script_filename, script_content):
+    def _get_script_url(self, script_filename, script_content):
         """Accept filename and content, and write it to the fileserver"""
 
         script_path, script_url = self._generate_script_path_and_url(

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -245,7 +245,7 @@ def _http_rest_host(cloudify_agent):
 
 
 def _get_init_script_path_and_url(new_agent, old_agent_version):
-    script_path, script_url = install_script_download_link(new_agent)
+    script_url = install_script_download_link(new_agent)
     # Prior to 4.2 (and script plugin 1.5.1) there was no way to pass
     # a certificate to the script plugin, so the initial script must be
     # passed over http
@@ -254,7 +254,7 @@ def _get_init_script_path_and_url(new_agent, old_agent_version):
         link_relpath = script_url.split('/', 3)[3]
         script_url = urljoin(_http_rest_host(new_agent), link_relpath)
 
-    return script_path, script_url
+    return script_url
 
 
 def _validate_created_agent(new_agent):
@@ -387,7 +387,7 @@ def _run_install_script(old_agent, timeout):
         # this agent was installed by current manager.
         old_agent['version'] = str(_get_manager_version())
     new_agent = create_new_agent_config(old_agent)
-    _, script_url = _get_init_script_path_and_url(
+    script_url = _get_init_script_path_and_url(
         new_agent, old_agent['version']
     )
     new_agent_connection = {
@@ -422,7 +422,7 @@ def _stop_old_diamond(old_agent, timeout):
 
 def _stop_old_agent(new_agent, old_agent, timeout):
     ctx.logger.info('Stopping old Cloudify agent...')
-    _, script_url = stop_agent_script_download_link(
+    script_url = stop_agent_script_download_link(
         new_agent,
         old_agent_name=old_agent['name']
     )

--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -281,6 +281,8 @@ def _get_cloudify_context(agent, task_name, new_agent_connection=None):
         'node_id': ctx.instance.id,
         'workflow_id': ctx.workflow_id,
         'execution_id': ctx.execution_id,
+        'execution_token': ctx.execution_token,
+        'deployment_id': ctx.deployment.id,
         'tenant': ctx.tenant,
         'rest_token': get_rest_token(),
         'rest_host': ctx.rest_host,


### PR DESCRIPTION
Instead of direct filesystem access, upload the scripts (and then delete) to the fileserver using ctx methods.