### PR TITLE
Remove early return for empty IP and cert

### DIFF
--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -612,8 +612,6 @@ def _get_broker_config(agent):
 
 
 def _update_broker_config(agent, manager_ip, manager_cert):
-    if not manager_ip and not manager_cert:
-        return
     broker_conf = agent.setdefault('broker_config', dict())
     if manager_ip:
         agent['broker_ip'] = manager_ip


### PR DESCRIPTION
This is necessary following https://github.com/cloudify-cosmo/cloudify-agent/pull/899,
since the manager_ip and cert will be empty during the upgrade to the new agents (7+)