### PR TITLE
Remove early return for empty IP and cert

### DIFF
--- a/cloudify_agent/operations.py
+++ b/cloudify_agent/operations.py
@@ -612,8 +612,6 @@ def _get_broker_config(agent):
 
 
 def _update_broker_config(agent, manager_ip, manager_cert):
-    if not manager_ip and not manager_cert:
-        return
     broker_conf = agent.setdefault('broker_config', dict())
     if manager_ip:
         agent['broker_ip'] = manager_ip

--- a/cloudify_agent/tests/resources/blueprints/agent-from-package/local-agent-blueprint.yaml
+++ b/cloudify_agent/tests/resources/blueprints/agent-from-package/local-agent-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_5
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/7.0.2.dev1/types.yaml
+  - http://www.getcloudify.org/spec/cloudify/7.0.1/types.yaml
 
 inputs:
 

--- a/cloudify_agent/tests/resources/blueprints/install-agent/test-install-agent-blueprint-windows.yaml
+++ b/cloudify_agent/tests/resources/blueprints/install-agent/test-install-agent-blueprint-windows.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_5
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/7.0.2.dev1/types.yaml
+    - http://www.getcloudify.org/spec/cloudify/7.0.1/types.yaml
 
 node_templates:
   node:

--- a/cloudify_agent/tests/resources/blueprints/install-agent/test-install-agent-blueprint.yaml
+++ b/cloudify_agent/tests/resources/blueprints/install-agent/test-install-agent-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_5
 
 imports:
-    - http://www.getcloudify.org/spec/cloudify/7.0.2.dev1/types.yaml
+    - http://www.getcloudify.org/spec/cloudify/7.0.1/types.yaml
 
 node_templates:
   node:

--- a/cloudify_agent/tests/resources/blueprints/install-new-agent/install-new-agent-blueprint.yaml
+++ b/cloudify_agent/tests/resources/blueprints/install-new-agent/install-new-agent-blueprint.yaml
@@ -1,7 +1,7 @@
 tosca_definitions_version: cloudify_dsl_1_3
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/7.0.2.dev1/types.yaml
+  - http://www.getcloudify.org/spec/cloudify/6.3.0/types.yaml
 
 inputs:
 

--- a/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
+++ b/jenkins/bp/ec2-cfy-agent-tests-blueprint.yaml
@@ -3,7 +3,7 @@ tosca_definitions_version: cloudify_dsl_1_3
 description: >
   This blueprint deploy EC2 for agent tests
 imports:
-  - http://cloudify.co/spec/cloudify/7.0.2.dev1/types.yaml
+  - http://cloudify.co/spec/cloudify/6.3.0/types.yaml
   - plugin:cloudify-aws-plugin?version= >=3.0.3
   - plugin:cloudify-utilities-plugin
 
@@ -305,4 +305,4 @@ capabilities:
 
   key_content:
     description: Private agent key
-    value: { get_attribute: [agent_key, private_key_export] } 
+    value: { get_attribute: [agent_key, private_key_export] }


### PR DESCRIPTION
This is necessary following https://github.com/cloudify-cosmo/cloudify-agent/pull/899,
since the manager_ip and cert will be empty during the upgrade to the new agents (7+)